### PR TITLE
Fixed error msg on startup

### DIFF
--- a/app/scanner/core.py
+++ b/app/scanner/core.py
@@ -152,7 +152,7 @@ class Scanner:
             clauses.append(f"-iname '*{ext}'")
         
         or_clause = " -o ".join(clauses)
-        cmd = f"find {safe_root} -type f \( {or_clause} \) -print | wc -l"
+        cmd = f"find {safe_root} -type f \\( {or_clause} \\) -print | wc -l"
         
         try:
             proc = await asyncio.create_subprocess_shell(


### PR DESCRIPTION
I have fixed the SyntaxWarning in `app/scanner/core.py` by properly escaping the backslashes in the find command string.

The line was previously:
```python
cmd = f"find {safe_root} -type f \( {or_clause} \) -print | wc -l"
```

And has been changed to:
```python
cmd = f"find {safe_root} -type f \\( {or_clause} \\) -print | wc -l"
```

This ensures that Python treats the backslashes as literal characters to be passed to the shell, and eliminates the warning about invalid escape sequences. The server should now start without these warnings.