### PR TITLE
Fixed my history and added a refresh button to history page

### DIFF
--- a/app/api/player.py
+++ b/app/api/player.py
@@ -204,21 +204,36 @@ async def monitor_upnp_playback(udn: str):
                     queue = state.get("queue") or []
                     if 0 <= state["current_index"] < len(queue):
                         track = queue[state["current_index"]]
-                        track_id = track.get("id")
-                        duration = track.get("duration_seconds") or 0
-                        renderer_ip = (
-                            upnp.renderers.get(udn, {}).get("ip")
-                            if upnp.renderers
-                            else None
-                        )
-                        if _should_log_history(udn, track_id, rel_time, duration):
-                            await log_history(
-                                db,
-                                track_id,
-                                client_ip=renderer_ip or "unknown",
-                                client_id=udn,
-                                user_id=track.get("user_id"),
-                            )
+                        
+                        # Only check if not already logged
+                        if not track.get("logged", False):
+                            track_id = track.get("id")
+                            duration = track.get("duration_seconds") or 0
+                            
+                            # Threshold check
+                            threshold = min(30, duration * 0.2) if duration > 0 else 30
+                            
+                            if rel_time >= threshold:
+                                renderer_ip = (
+                                    upnp.renderers.get(udn, {}).get("ip")
+                                    if upnp.renderers
+                                    else None
+                                )
+                                await log_history(
+                                    db,
+                                    track_id,
+                                    client_ip=renderer_ip or "unknown",
+                                    client_id=udn,
+                                    user_id=track.get("user_id"),
+                                )
+                                
+                                # Mark logged and persist
+                                track["logged"] = True
+                                await db.execute(
+                                    "UPDATE renderer_state SET queue = $1 WHERE renderer_udn = $2",
+                                    json.dumps(queue),
+                                    udn,
+                                )
 
             # Execute side effects outside DB context (avoids holding a transaction open)
             if was_playing and transport_state in ["STOPPED", "NO_MEDIA_PRESENT"]:
@@ -257,6 +272,7 @@ class Track(BaseModel):
     disc_no: Optional[int] = None
     date: Optional[str] = None
     bitrate: Optional[int] = None
+    logged: bool = False
 
 
 class PlayerState(BaseModel):
@@ -711,7 +727,7 @@ async def get_playback_history_stats(
         where_clauses = ["DATE(timestamp) >= CURRENT_DATE + CAST($1 AS INTERVAL)"]
         params: List[Any] = [timedelta(days=-(days - 1))]
         if scope == "mine" and user_row:
-            where_clauses.append("h.user_id = ?")
+            where_clauses.append("h.user_id = $2")
             params.append(user_row["id"])
         where_sql = " AND ".join(where_clauses)
 
@@ -728,12 +744,16 @@ async def get_playback_history_stats(
 
         # Top artists
         artists_query = f"""
-            SELECT t.artist, MIN(t.artwork_id) as artwork_id, MAX(a.sha1) as art_sha1, COUNT(*) as plays
+            SELECT 
+                COALESCE(NULLIF(t.album_artist, ''), t.artist) as artist_name, 
+                MIN(t.artwork_id) as artwork_id, 
+                MAX(a.sha1) as art_sha1, 
+                COUNT(*) as plays
             FROM playback_history h
             JOIN track t ON t.id = h.track_id
             LEFT JOIN artwork a ON t.artwork_id = a.id
             WHERE {where_sql}
-            GROUP BY t.artist
+            GROUP BY COALESCE(NULLIF(t.album_artist, ''), t.artist)
             ORDER BY plays DESC
             LIMIT 10
         """
@@ -752,12 +772,17 @@ async def get_playback_history_stats(
 
         # Top albums
         albums_query = f"""
-            SELECT t.album, t.artist, MIN(t.artwork_id) as artwork_id, MAX(a.sha1) as art_sha1, COUNT(*) as plays
+            SELECT 
+                t.album, 
+                COALESCE(NULLIF(t.album_artist, ''), t.artist) as artist_name, 
+                MIN(t.artwork_id) as artwork_id, 
+                MAX(a.sha1) as art_sha1, 
+                COUNT(*) as plays
             FROM playback_history h
             JOIN track t ON t.id = h.track_id
             LEFT JOIN artwork a ON t.artwork_id = a.id
                 WHERE {where_sql}
-                GROUP BY t.album, t.artist
+                GROUP BY t.album, COALESCE(NULLIF(t.album_artist, ''), t.artist)
                 ORDER BY plays DESC
                 LIMIT 10
             """
@@ -1036,29 +1061,42 @@ async def update_progress(
             state = await get_renderer_state_db(db, udn)
             state["position_seconds"] = update.position_seconds
             state["is_playing"] = update.is_playing
-            await update_renderer_state_db(db, udn, state)
 
-            # Server-side history logging for local playback
+            # Check for history logging
             if state["current_index"] is not None and state["current_index"] >= 0:
                 queue = state.get("queue") or []
                 if 0 <= state["current_index"] < len(queue):
                     track = queue[state["current_index"]]
-                    track_id = track.get("id")
-                    duration = track.get("duration_seconds") or 0
-                    if _should_log_history(
-                        client_id, track_id, update.position_seconds, duration
-                    ):
-                        # Prefer session user, fall back to queued track owner if missing
-                        effective_user_id = (
-                            user_id if user_id is not None else track.get("user_id")
-                        )
-                        await log_history(
-                            db,
-                            track_id,
-                            client_ip=client_ip,
-                            client_id=client_id,
-                            user_id=effective_user_id,
-                        )
+                    
+                    # Only log if not already logged
+                    if not track.get("logged", False):
+                        duration = track.get("duration_seconds") or 0
+                        # Check threshold (30s or 20%)
+                        threshold = min(30, duration * 0.2) if duration > 0 else 30
+                        
+                        if update.position_seconds >= threshold:
+                            # Log it
+                            effective_user_id = (
+                                user_id if user_id is not None else track.get("user_id")
+                            )
+                            try:
+                                await log_history(
+                                    db,
+                                    track.get("id"),
+                                    client_ip=client_ip,
+                                    client_id=client_id,
+                                    user_id=effective_user_id,
+                                )
+                            except Exception as e:
+                                logger.error(f"Failed to log history: {e}")
+                            
+                            # Mark as logged and persist
+                            track["logged"] = True
+                            # Queue is already ref in state, so just save state
+                            await update_renderer_state_db(db, udn, state)
+            
+            # Save state (position/playing updates)
+            await update_renderer_state_db(db, udn, state)
         else:
             # For remote renderers, skip logging here to avoid double-reporting with UPnP monitor
             state = await get_renderer_state_db(db, udn)

--- a/tests/api/test_player.py
+++ b/tests/api/test_player.py
@@ -167,9 +167,23 @@ async def test_progress_logs_history(client: AsyncClient, db, player_data):
     assert response.status_code == 200
     
     # Verify insertion
-    # Allow small delay for async db ops if any (though here it's awaited)
     rows = await db.fetch("SELECT * FROM playback_history WHERE track_id = 10")
-    assert len(rows) > 0
+    assert len(rows) == 1
+
+    # Verify state persistence (logged flag)
+    response = await client.get("/api/player/state", headers=headers)
+    state = response.json()
+    assert state['queue'][0]['logged'] is True
+
+    # Send another progress update, should NOT log again
+    response = await client.post("/api/player/progress", 
+        json={"position_seconds": 40, "is_playing": True},
+        headers=headers
+    )
+    assert response.status_code == 200
+    
+    rows = await db.fetch("SELECT * FROM playback_history WHERE track_id = 10")
+    assert len(rows) == 1
 
 @pytest.mark.asyncio
 async def test_renderers(client: AsyncClient, db):
@@ -218,6 +232,61 @@ async def test_set_renderer_persists_session(client: AsyncClient, db):
     resp = await client.post("/api/player/renderer", json={"udn": udn}, headers=headers)
     assert resp.status_code == 200, resp.text
     assert resp.json()["active"] == udn
-
     row = await db.fetchrow("SELECT active_renderer_udn FROM client_session WHERE client_id=$1", "renderer-test")
     assert row and row["active_renderer_udn"] == udn
+
+@pytest.mark.asyncio
+async def test_history_grouping(client: AsyncClient, db, auth_token):
+    # Insert Album Artist = "Main", Artist = "Main"
+    await db.execute("""
+        INSERT INTO track (id, title, artist, album_artist, album, duration_seconds, track_no, path)
+        VALUES (101, 'Solo', 'Main', 'Main', 'AlbumX', 200, 1, '/music/solo.flac')
+    """)
+    # Insert Album Artist = "Main", Artist = "Main & Feat"
+    await db.execute("""
+        INSERT INTO track (id, title, artist, album_artist, album, duration_seconds, track_no, path)
+        VALUES (102, 'Feat', 'Main & Feat', 'Main', 'AlbumX', 200, 2, '/music/feat.flac')
+    """)
+    
+    # Log plays for both
+    for tid in [101, 102]:
+        await db.execute(
+            "INSERT INTO playback_history (track_id, timestamp, client_ip) VALUES ($1, NOW(), '127.0.0.1')",
+            tid
+        )
+        
+    response = await client.get("/api/player/history/stats")
+    stats = response.json()
+    
+    # Expect 1 Artist entry ("Main") with 2 plays
+    artists = stats["artists"]
+    assert len(artists) == 1
+    assert artists[0]["artist"] == "Main"
+    assert artists[0]["plays"] == 2
+    
+    # Expect 1 Album entry ("AlbumX") with 2 plays
+    albums = stats["albums"]
+    assert len(albums) == 1
+    assert albums[0]["album"] == "AlbumX"
+    assert albums[0]["plays"] == 2
+
+@pytest.mark.asyncio
+async def test_history_stats_mine_scope(client: AsyncClient, db, player_data, auth_token):
+    # Get user id from generated token
+    user = await db.fetchrow("SELECT id FROM \"user\" WHERE username = $1", "testuser")
+    assert user is not None
+    user_id = user["id"]
+
+    # Insert history for this user
+    await db.execute("""
+        INSERT INTO playback_history (track_id, client_ip, user_id, timestamp)
+        VALUES (10, '127.0.0.1', $1, NOW())
+    """, user_id)
+    
+    # Request with scope=mine
+    cookies = {"jamarr_session": auth_token}
+    response = await client.get("/api/player/history/stats?scope=mine", cookies=cookies)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["tracks"]) >= 1
+    assert data["tracks"][0]["plays"] == 1

--- a/web/src/lib/components/PlayerBar.svelte
+++ b/web/src/lib/components/PlayerBar.svelte
@@ -81,10 +81,16 @@
   } 
   */
 
+  let lastUpdateTime = 0; // Track last time we sent progress to server
+
   // Reset logged flag when track ID actually changes
   $: if (currentTrack && currentTrack.id !== lastLoggedTrackId) {
     hasLoggedCurrentTrack = false;
-    console.log("[PlayerBar] Track changed, reset hasLoggedCurrentTrack");
+    lastLoggedTrackId = currentTrack.id;
+    lastUpdateTime = 0; // Reset progress reporting timer
+    console.log(
+      "[PlayerBar] Track changed, reset hasLoggedCurrentTrack and lastUpdateTime",
+    );
   }
 
   // Auto-resume playback when queue is loaded (reactive)
@@ -247,7 +253,6 @@
         "[PlayerBar] Audio element found, adding timeupdate and ended listeners",
       );
       let timeupdateCount = 0;
-      let lastUpdateTime = 0;
       audio.addEventListener("timeupdate", () => {
         timeupdateCount++;
         const oldProgress = progress;

--- a/web/src/lib/stores/player.ts
+++ b/web/src/lib/stores/player.ts
@@ -271,29 +271,25 @@ export async function previous() {
     }
 }
 
-// Debounce progress updates
-let progressUpdateTimeout: any;
-export function updateProgress(seconds: number, isPlaying: boolean) {
+// Throttling handled by caller (PlayerBar.svelte)
+export async function updateProgress(seconds: number, isPlaying: boolean) {
     playerState.update(s => ({ ...s, position_seconds: seconds, is_playing: isPlaying }));
 
-    clearTimeout(progressUpdateTimeout);
-    progressUpdateTimeout = setTimeout(async () => {
-        // console.log('[updateProgress] Sending to server:', { position_seconds: seconds, is_playing: isPlaying });
-        try {
-            const res = await fetch('/api/player/progress', {
-                method: 'POST',
-                headers: getHeaders(),
-                body: JSON.stringify({ position_seconds: seconds, is_playing: isPlaying })
-            });
-            if (res.ok) {
-                // console.log('[updateProgress] Server updated successfully');
-            } else {
-                console.error('[updateProgress] Server update failed:', res.status);
-            }
-        } catch (e) {
-            console.error('[updateProgress] Failed to update progress', e);
+    console.log('[updateProgress] Sending to server:', { position_seconds: seconds, is_playing: isPlaying });
+    try {
+        const res = await fetch('/api/player/progress', {
+            method: 'POST',
+            headers: getHeaders(),
+            body: JSON.stringify({ position_seconds: seconds, is_playing: isPlaying })
+        });
+        if (res.ok) {
+            // console.log('[updateProgress] Server updated successfully');
+        } else {
+            console.error('[updateProgress] Server update failed:', res.status);
         }
-    }, 5000); // Update server every 5 seconds
+    } catch (e) {
+        console.error('[updateProgress] Failed to update progress', e);
+    }
 }
 
 

--- a/web/src/routes/history/+page.svelte
+++ b/web/src/routes/history/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { setQueue } from "$stores/player";
-  import { goto } from "$app/navigation";
+  import { goto, invalidateAll } from "$app/navigation";
 
   export let data: {
     history: Array<{
@@ -150,6 +150,26 @@
         on:click={() => switchScope("all")}
       >
         All History
+      </button>
+      <button
+        class="btn btn-sm btn-square border border-white/10 bg-white/5 text-white hover:bg-white/10"
+        on:click={() => invalidateAll()}
+        title="Refresh History"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-4 h-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+          />
+        </svg>
       </button>
       <div class="flex items-center gap-2 text-sm text-white/70">
         <label for="days" class="hidden md:inline">Days</label>


### PR DESCRIPTION
# Playback History Fixes & Improvements
We have successfully restored and improved the Playback History functionality. Below is a summary of changes, testing, and validation results.
## Changes Made
### 1. Fix: Reliable History Logging
- **Problem**: Tracks were not being logged because the frontend progress updates were being cancelled (debounced) before reaching the server.
- **Solution**: Removed the debounce delay in [web/src/lib/stores/player.ts](file:///root/code/jamarr/web/src/lib/stores/player.ts) to ensure [updateProgress](file:///root/code/jamarr/web/src/lib/stores/player.ts#274-294) API calls are sent immediately.
- **Backend Stability**: Fixed a `NameError` crash by ensuring the `duration` variable is correctly scoped in [app/api/player.py](file:///root/code/jamarr/app/api/player.py).
### 2. Fix: Continuous Progress Reporting (Multi-Track)
- **Problem**: History logging stopped working for subsequent tracks in the queue (logging only worked for the first played track).
- **Root Cause**: The frontend timer `lastUpdateTime`, which regulates the 5-second progress updates, was not resetting when the track changed.
- **Solution**: Moved `lastUpdateTime` to the component scope in [PlayerBar.svelte](file:///root/code/jamarr/web/src/lib/components/PlayerBar.svelte) and added logic to explicitly reset it to `0` whenever `currentTrack.id` changes.
### 3. Fix: Persistent Deduplication
- **Problem**: Server restarts (hot-reloading) were clearing the in-memory history tracker, causing duplicate logs for the same playing track.
- **Solution**: Implemented persistent state tracking. Added a `logged` flags to the [Track](file:///root/code/jamarr/app/api/player.py#257-276) model and [renderer_state](file:///root/code/jamarr/app/api/player.py#422-498) table. The server now checks the database state instead of volatile memory.
### 4. Improvement: Intelligent Grouping
- **Problem**: Collaborations (e.g., "Main Artist & Guest") were cluttering "Top Artists" stats as separate entries.
- **Solution**: Updated SQL queries for "Top Artists" and "Top Albums" to group by `Album Artist` (falling back to `Artist`). This merges collaborations under the main artist.
### 5. Fix: "My History" Error
- **Problem**: The "My History" filter caused a 500 error due to incompatible SQL placeholders (`?` vs `$1`).
- **Solution**: Corrected the SQL syntax in [app/api/player.py](file:///root/code/jamarr/app/api/player.py) for PostgreSQL compatibility.
### 6. Feature: History Refresh
- **New Feature**: Added a "Refresh" button to the history page to allow manual reloading of statistics without refreshing the entire browser page.
## Validation Results
### Automated Tests
- **`tests/api/test_player.py:test_history_grouping`**: ✅ PASSED. Verified that multiple tracks with different artists but same album artist are grouped correctly in stats.
- **`tests/api/test_player.py:test_progress_logs_history`**: ✅ PASSED. Verified that hitting the playback threshold triggers a DB insert.
### Manual Verification
- **Logging logic**: Verified via real-time logs that [update_progress](file:///root/code/jamarr/app/api/player.py#1051-1104) is received, threshold is calculated, and [log_history](file:///root/code/jamarr/app/api/player.py#565-631) is called successfully.
- **Crash Recovery**: Verified server logs confirm successful startup and operation.
- **Continuous Playback**: Confirmed that progress updates reset and continue for subsequent tracks in the queue.