### PR TITLE
Change to top track and singles matching

### DIFF
--- a/app/scanner/metadata.py
+++ b/app/scanner/metadata.py
@@ -543,9 +543,9 @@ async def match_track_to_library(
     Returns track_id if found, None otherwise.
     """
     # Get all tracks for this artist (including features)
-    # We also fetch MB IDs now
+    # We also fetch MB IDs and Date now
     query = """
-        SELECT t.id, t.title, t.album, t.duration_seconds, t.track_mbid, t.release_track_mbid
+        SELECT t.id, t.title, t.album, t.duration_seconds, t.track_mbid, t.release_track_mbid, t.date
         FROM track t
         JOIN track_artist ta ON t.id = ta.track_id
         WHERE ta.artist_mbid = $1 
@@ -559,7 +559,7 @@ async def match_track_to_library(
     # 1. Exact MBID Match (Highest Priority)
     if external_mb_track_id:
         for row in candidates:
-            cid, ctitle, calbum, cseconds, cmb_track_id, cmb_release_track_id = row
+            cid, ctitle, calbum, cseconds, cmb_track_id, cmb_release_track_id, cdate = row
             if (
                 cmb_track_id == external_mb_track_id
                 or cmb_release_track_id == external_mb_track_id
@@ -582,12 +582,33 @@ async def match_track_to_library(
     def fuzzy_score(s1, s2):
         return difflib.SequenceMatcher(None, normalize(s1), normalize(s2)).ratio()
 
+    def normalize_date(d_str):
+        """
+        Normalize date string to YYYY-MM-DD for comparison.
+        If only YYYY is provided, defaults to YYYY-01-01.
+        Returns None if invalid.
+        """
+        if not d_str:
+            return None
+        d_str = d_str.strip()
+        # Handle YYYY
+        if len(d_str) == 4 and d_str.isdigit():
+            return f"{d_str}-01-01"
+        # Handle YYYY-MM (Default to 01)
+        if len(d_str) == 7 and d_str.replace("-","").isdigit():
+            return f"{d_str}-01"
+        # Handle YYYY-MM-DD
+        if len(d_str) >= 10:
+            return d_str[:10]
+        return None
+
     # Calculate scores
     best_score = 0
     best_match = None
+    best_date = None
 
     for row in candidates:
-        cid, ctitle, calbum, cseconds, cmb_track_id, cmb_release_track_id = row
+        cid, ctitle, calbum, cseconds, cmb_track_id, cmb_release_track_id, cdate = row
 
         # Dynamic Weighting
         total_weight = 0.6
@@ -605,19 +626,24 @@ async def match_track_to_library(
             a_score = fuzzy_score(album_name, calbum)
             current_score += a_score * 0.2
 
-        # 3. Duration Score (Weight 0.2 if applicable)
-        # We rely on caller passing correct info, but currently they pass None mostly.
-        # However, checking if duration exists in DB row is good.
-        # But we need external duration to compare against.
-        # Since the function signature doesn't support duration yet, we skip this part
-        # basically making it Title(60%) + Album(20%) logic, which we verified works for Singles (Title 60/60 = 100%).
-
         # Normalize
         final_score = current_score / total_weight
+        norm_date = normalize_date(cdate)
 
         if final_score > best_score:
             best_score = final_score
             best_match = cid
+            best_date = norm_date
+        elif abs(final_score - best_score) < 0.001 and best_score > 0:
+            # Tie-breaker: Prefer earlier date
+            if norm_date and best_date:
+                if norm_date < best_date:
+                    best_match = cid
+                    best_date = norm_date
+            elif norm_date and not best_date:
+                # Prefer candidate with a date over one without
+                best_match = cid
+                best_date = norm_date
 
     if best_score > 0.75:
         return best_match

--- a/tests/unit/test_metadata_matching.py
+++ b/tests/unit/test_metadata_matching.py
@@ -1,0 +1,112 @@
+
+import pytest
+from unittest.mock import AsyncMock
+from app.scanner.metadata import match_track_to_library
+
+@pytest.mark.asyncio
+async def test_match_track_basic_match():
+    """
+    Test basic matching functionality where one candidate clearly wins.
+    """
+    mock_db = AsyncMock()
+    # Mock data: id, title, album, duration, track_mbid, release_track_mbid, date
+    candidates = [
+        (1, "Hometown Glory", "19", 250, "mbid-1", "rmbid-1", "2008-01-28"),
+        (2, "Some Other Song", "19", 200, "mbid-2", "rmbid-2", "2008-01-28"),
+    ]
+    mock_db.fetch.return_value = candidates
+
+    # Pass album_name="19" which boosts score for candidate 1
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Hometown Glory", album_name="19")
+    assert match_id == 1
+
+@pytest.mark.asyncio
+async def test_match_track_date_tiebreaker_studio_vs_live():
+    """
+    Test tie-breaking logic where two tracks match well but one is earlier (Studio) and one is later (Live).
+    """
+    mock_db = AsyncMock()
+    # Scenario: Finding "Hometown Glory". 
+    # Candidate 2 (Live) is "Live at the Royal Albert Hall" (2011)
+    # Candidate 1 (Studio) is "19" (2008)
+    
+    # Even if we don't provide album_name (simulating just track title match)
+    # Both will score 1.0 on title. The tie-breaker should pick the earlier date.
+    
+    # We order them such that Live is first, to ensure "first found" isn't the winner
+    candidates = [
+        (101, "Hometown Glory", "Live at the Royal Albert Hall", 250, "mbid-live", "rel-mbid-live", "2011-11-29"),
+        (102, "Hometown Glory", "19", 250, "mbid-19", "rel-mbid-19", "2008-01-28"),
+    ]
+    mock_db.fetch.return_value = candidates
+
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Hometown Glory", album_name=None)
+    
+    # Should pick 102 (2008)
+    assert match_id == 102
+
+@pytest.mark.asyncio
+async def test_match_track_date_tiebreaker_studio_vs_live_reverse_order():
+    """
+    Test tie-breaking logic ensures order doesn't matter.
+    """
+    mock_db = AsyncMock()
+    # Studio first this time
+    candidates = [
+        (102, "Hometown Glory", "19", 250, "mbid-19", "rel-mbid-19", "2008-01-28"),
+        (101, "Hometown Glory", "Live at the Royal Albert Hall", 250, "mbid-live", "rel-mbid-live", "2011-11-29"),
+    ]
+    mock_db.fetch.return_value = candidates
+
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Hometown Glory", album_name=None)
+    
+    # Should still pick 102 (2008)
+    assert match_id == 102
+
+@pytest.mark.asyncio
+async def test_match_track_date_normalization_year_only():
+    """
+    Test that year-only dates are handled correctly (YYYY -> YYYY-01-01).
+    """
+    mock_db = AsyncMock()
+    candidates = [
+        (201, "Track A", "Album A", 200, "m1", "r1", "2010"),      # Treating as 2010-01-01
+        (202, "Track A", "Album B", 200, "m2", "r2", "2009-12-31") # Earlier
+    ]
+    mock_db.fetch.return_value = candidates
+    
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Track A", album_name=None)
+    assert match_id == 202
+
+@pytest.mark.asyncio
+async def test_match_track_date_vs_no_date():
+    """
+    Test that a track with a date is preferred over one without, if match score is tied.
+    """
+    mock_db = AsyncMock()
+    candidates = [
+        (301, "Track X", "Album X", 200, "m1", "r1", None),     
+        (302, "Track X", "Album Y", 200, "m2", "r2", "2020"), 
+    ]
+    mock_db.fetch.return_value = candidates
+    
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Track X", album_name=None)
+    assert match_id == 302
+
+@pytest.mark.asyncio
+async def test_match_prefer_better_score_over_date():
+    """
+    Ensure we don't pick an earlier track if the match score is significantly worse.
+    """
+    mock_db = AsyncMock()
+    # Candidate 1: Exact title match, later date
+    # Candidate 2: Partial title match, earlier date
+    candidates = [
+        (401, "Exact Title Match", "Album New", 200, "m1", "r1", "2020"),
+        (402, "Exact Title But Not Really", "Album Old", 200, "m2", "r2", "1990"),
+    ]
+    mock_db.fetch.return_value = candidates
+    
+    match_id = await match_track_to_library(mock_db, "artist-mbid", "Exact Title Match", album_name=None)
+    assert match_id == 401
+


### PR DESCRIPTION
# Improved Track Matching Logic

## Summary
I have improved the track matching logic to prioritize the **earliest release date** when multiple candidates have the same match score. This resolves the issue where live versions (e.g., *Live at the Royal Albert Hall*, 2011) were sometimes chosen over studio versions (e.g., *19*, 2008) purely based on undefined database ordering.

## Changes

### 1. Database Query Update
Updated the [match_track_to_library](file:///root/code/jamarr/app/scanner/metadata.py#538-652) function to fetch the [date](file:///root/code/jamarr/app/scanner/core.py#1999-2016) field from the track table.

### 2. Tie-Breaking Logic
When two candidates have an identical match score (e.g., both have an exact title match):
- The logic now attempts to parse the date (handling `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`).
- It prioritizes the **earliest** date.
- This ensures the original studio recording is favored over later live performances or compilations.

```python
        elif abs(final_score - best_score) < 0.001 and best_score > 0:
            # Tie-breaker: Prefer earlier date
            if norm_date and best_date:
                if norm_date < best_date:
                    best_match = cid
                    best_date = norm_date
```

## Verification Results

### Automated Tests
I added a new unit test suite [tests/unit/test_metadata_matching.py](file:///root/code/jamarr/tests/unit/test_metadata_matching.py) covering:
- Basic matching functionality.
- **Studio vs. Live scenarios** (Tie-breaking by date).
- Date parsing robustness.

**Test Output:**
```
tests/unit/test_metadata_matching.py ...... [100%]
6 passed in 0.23s
```

### Manual Verification
Ran a reproduction script ([repro_match.py](file:///root/code/jamarr/repro_match.py) / [demo_fix.py](file:///root/code/jamarr/demo_fix.py)) which confirmed:
- **Before**: "Hometown Glory" matched to *Live at the Royal Albert Hall* (2011) in some orderings.
- **After**: "Hometown Glory" reliably matches *19* (2008) regardless of input order.

