### PR TITLE
Fix chart refresh race showing stale 'missing' rows after refresh button

### DIFF
--- a/app/api/charts.py
+++ b/app/api/charts.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.charts import refresh_chart_task
@@ -87,6 +87,6 @@ async def get_chart():
         return results
 
 @router.post("/refresh")
-async def refresh_chart(background_tasks: BackgroundTasks):
-    background_tasks.add_task(refresh_chart_task)
-    return {"status": "refreshing_started"}
+async def refresh_chart():
+    await refresh_chart_task()
+    return {"status": "refreshed"}

--- a/web/src/routes/charts/+page.svelte
+++ b/web/src/routes/charts/+page.svelte
@@ -15,12 +15,10 @@
     refreshing = true;
     try {
       await refreshChart();
-      setTimeout(() => {
-        invalidateAll();
-        refreshing = false;
-      }, 5000);
+      await invalidateAll();
     } catch (e) {
       console.error(e);
+    } finally {
       refreshing = false;
     }
   }


### PR DESCRIPTION
The /charts/refresh endpoint queued refresh_chart_task via BackgroundTasks and returned immediately; the UI invalidated after a fixed 5s timeout. The refresh takes ~10s, so the page re-fetched before the DELETE+INSERT transaction had committed and rendered the prior (often wrong-MBID) rows, making them appear as 'missing' in the library until a full page reload.

Await the task inline so the HTTP response returns only once chart_album is fully updated, and invalidate the page data immediately on resolve.