### PR TITLE
Fix production client IP logging and scheduler shutdown

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+import asyncpg
 from croniter import croniter
 
 from app.db import get_pool
@@ -174,8 +175,15 @@ class Scheduler:
                 await self._lock_conn.execute(
                     "SELECT pg_advisory_unlock($1)", LOCK_KEY
                 )
+            except asyncpg.InterfaceError:
+                logger.warning(
+                    "Scheduler lock connection was already released before unlock."
+                )
             finally:
-                await get_pool().release(self._lock_conn)
+                try:
+                    await get_pool().release(self._lock_conn)
+                except asyncpg.InterfaceError:
+                    pass
                 self._lock_conn = None
         logger.info("Scheduler stopped.")
 

--- a/app/security.py
+++ b/app/security.py
@@ -116,8 +116,24 @@ def configure_security_middleware(app: FastAPI) -> None:
         )
 
 
+def _trusted_proxy_ips() -> set[str]:
+    return set(parse_csv_env("TRUSTED_PROXY_IPS"))
+
+
 def get_client_ip(request: Request) -> str:
-    return request.client.host if request.client else "unknown"
+    direct_ip = request.client.host if request.client else "unknown"
+    if direct_ip in _trusted_proxy_ips():
+        forwarded_for = request.headers.get("x-forwarded-for", "")
+        if forwarded_for:
+            first_hop = forwarded_for.split(",", 1)[0].strip()
+            if first_hop:
+                return first_hop
+
+        real_ip = request.headers.get("x-real-ip", "").strip()
+        if real_ip:
+            return real_ip
+
+    return direct_ip
 
 
 def log_security_event(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import asyncpg
+import pytest
+
+from app.scheduler import Scheduler
+
+
+class _ReleasedLockConnection:
+    async def execute(self, *_args, **_kwargs):
+        raise asyncpg.InterfaceError(
+            "cannot call Connection.execute(): connection has been released back to the pool"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_stop_tolerates_released_lock_connection(monkeypatch):
+    scheduler = Scheduler()
+    scheduler._lock_conn = _ReleasedLockConnection()
+
+    pool = SimpleNamespace()
+
+    async def release(_conn):
+        raise asyncpg.InterfaceError(
+            "cannot call Connection.release(): connection has been released back to the pool"
+        )
+
+    pool.release = release
+    monkeypatch.setattr("app.scheduler.get_pool", lambda: pool)
+
+    await scheduler.stop()
+
+    assert scheduler._lock_conn is None

--- a/tests/test_security_config.py
+++ b/tests/test_security_config.py
@@ -221,3 +221,27 @@ async def test_proxy_headers_are_trusted_only_from_configured_proxy(monkeypatch)
 
     assert trusted.json() == {"client_ip": "203.0.113.50", "scheme": "https"}
     assert untrusted.json() == {"client_ip": "192.168.1.50", "scheme": "http"}
+
+
+@pytest.mark.asyncio
+async def test_get_client_ip_uses_forwarded_headers_for_trusted_proxy(monkeypatch):
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "192.168.1.103")
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request):
+        return {"client_ip": get_client_ip(request)}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("192.168.1.103", 12345)),
+        base_url="http://192.168.1.107:8111",
+    ) as client:
+        response = await client.get(
+            "/whoami",
+            headers={
+                "X-Forwarded-For": "198.51.100.77, 192.168.1.103",
+                "X-Real-IP": "198.51.100.77",
+            },
+        )
+
+    assert response.json() == {"client_ip": "198.51.100.77"}


### PR DESCRIPTION
## Summary

This follow-up fixes two production issues found after deploying the internet-hardening work:

- access/security logs were recording the nginx proxy IP (`192.168.1.103`) instead of the real client IP
- scheduler shutdown could fail with `asyncpg InterfaceError` if the advisory-lock connection had already been released back to the pool

## Changes

- Update `get_client_ip()` to prefer `X-Forwarded-For` / `X-Real-IP` when the direct peer is in `TRUSTED_PROXY_IPS`
- Make `Scheduler.stop()` tolerate a released lock connection during shutdown instead of crashing app shutdown
- Add regression tests for trusted-proxy client IP extraction
- Add regression tests for scheduler shutdown with a released lock connection

## Verification

- `python3 -m compileall app tests`
- `./test.sh tests/test_security_config.py tests/test_scheduler.py tests/test_logging_conf.py tests/api/test_monitoring.py`
- Full `./test.sh`: `304 passed, 1 skipped`
