### PR TITLE
Add per-user favorites for artists and releases

### DIFF
--- a/app/api/favorites.py
+++ b/app/api/favorites.py
@@ -1,0 +1,86 @@
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from app.api.deps import get_current_user_jwt
+from app.db import get_db
+
+
+router = APIRouter(
+    prefix="/api/favorites",
+    tags=["favorites"],
+    dependencies=[Depends(get_current_user_jwt)],
+)
+
+
+class FavoriteToggleRequest(BaseModel):
+    favorite: bool
+
+
+async def _ensure_exists(
+    db: asyncpg.Connection, table: str, key_column: str, value: str
+) -> None:
+    row = await db.fetchrow(
+        f"SELECT 1 FROM {table} WHERE {key_column} = $1",
+        value,
+    )
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+
+@router.put("/artists/{artist_mbid}")
+async def toggle_artist_favorite(
+    artist_mbid: str,
+    payload: FavoriteToggleRequest,
+    user: asyncpg.Record = Depends(get_current_user_jwt),
+    db: asyncpg.Connection = Depends(get_db),
+):
+    await _ensure_exists(db, "artist", "mbid", artist_mbid)
+
+    if payload.favorite:
+        await db.execute(
+            """
+            INSERT INTO favorite_artist (user_id, artist_mbid)
+            VALUES ($1, $2)
+            ON CONFLICT (user_id, artist_mbid) DO NOTHING
+            """,
+            user["id"],
+            artist_mbid,
+        )
+    else:
+        await db.execute(
+            "DELETE FROM favorite_artist WHERE user_id = $1 AND artist_mbid = $2",
+            user["id"],
+            artist_mbid,
+        )
+
+    return {"artist_mbid": artist_mbid, "favorite": payload.favorite}
+
+
+@router.put("/releases/{album_mbid}")
+async def toggle_release_favorite(
+    album_mbid: str,
+    payload: FavoriteToggleRequest,
+    user: asyncpg.Record = Depends(get_current_user_jwt),
+    db: asyncpg.Connection = Depends(get_db),
+):
+    await _ensure_exists(db, "album", "mbid", album_mbid)
+
+    if payload.favorite:
+        await db.execute(
+            """
+            INSERT INTO favorite_release (user_id, album_mbid)
+            VALUES ($1, $2)
+            ON CONFLICT (user_id, album_mbid) DO NOTHING
+            """,
+            user["id"],
+            album_mbid,
+        )
+    else:
+        await db.execute(
+            "DELETE FROM favorite_release WHERE user_id = $1 AND album_mbid = $2",
+            user["id"],
+            album_mbid,
+        )
+
+    return {"album_mbid": album_mbid, "favorite": payload.favorite}

--- a/app/api/library.py
+++ b/app/api/library.py
@@ -117,6 +117,8 @@ async def get_artists(
     name: Optional[str] = None,
     mbid: Optional[str] = None,
     starts_with: Optional[str] = None,
+    favorite_only: bool = False,
+    user: asyncpg.Record = Depends(get_current_user_jwt),
     db: asyncpg.Connection = Depends(get_db),
 ):
     if not name and not mbid:
@@ -128,9 +130,12 @@ async def get_artists(
                 a.bio,
                 ar.sha1 as art_sha1,
                 COALESCE(ac.primary_count, 0) as primary_album_count,
-                COALESCE(ac.appears_count, 0) as appears_on_album_count
+                COALESCE(ac.appears_count, 0) as appears_on_album_count,
+                (fav.user_id IS NOT NULL) as is_favorite
             FROM artist a
             LEFT JOIN artwork ar ON a.artwork_id = ar.id
+            LEFT JOIN favorite_artist fav
+                ON fav.artist_mbid = a.mbid AND fav.user_id = $1
             -- Lateral join calculates counts ONLY for the artists returned by the main query
             LEFT JOIN LATERAL (
                 SELECT 
@@ -141,11 +146,15 @@ async def get_artists(
             ) ac ON TRUE
             WHERE a.name IS NOT NULL
         """
-        params = []
+        params = [user["id"]]
+        param_num = 2
         if starts_with:
             letter = "#" if starts_with == "#" else starts_with.upper()
-            query += " AND a.letter = $1"
+            query += f" AND a.letter = ${param_num}"
             params.append(letter)
+            param_num += 1
+        if favorite_only:
+            query += " AND fav.user_id IS NOT NULL"
         query += " ORDER BY LOWER(COALESCE(a.sort_name, a.name)), a.sort_name, a.name"
 
         rows = await db.fetch(query, *params)
@@ -158,6 +167,7 @@ async def get_artists(
                 "art_sha1": sha1_to_hex(row["art_sha1"]),
                 "primary_album_count": row["primary_album_count"],
                 "appears_on_album_count": row["appears_on_album_count"],
+                "is_favorite": row["is_favorite"],
             }
             for row in rows
         ]
@@ -183,9 +193,12 @@ async def get_artists(
             el.links->>'discogs' as discogs_url,
             COALESCE(ac.primary_count, 0) as primary_album_count,
             COALESCE(ac.appears_count, 0) as appears_on_album_count,
-            COALESCE(lp.listens, 0) as listens
+            COALESCE(lp.listens, 0) as listens,
+            (fav.user_id IS NOT NULL) as is_favorite
         FROM artist a
         LEFT JOIN artwork ar ON a.artwork_id = ar.id
+        LEFT JOIN favorite_artist fav
+            ON fav.artist_mbid = a.mbid AND fav.user_id = $1
         -- 1. Pivot External Links using JSONB for cleanliness and speed
         LEFT JOIN LATERAL (
             SELECT jsonb_object_agg(type, url) as links
@@ -210,8 +223,8 @@ async def get_artists(
         WHERE a.name IS NOT NULL
     """
 
-    params = []
-    param_num = 1
+    params = [user["id"]]
+    param_num = 2
     if name:
         # citext handles case-insensitivity
         query += f" AND REPLACE(a.name, '‐', '-') = REPLACE(${param_num}, '‐', '-')"
@@ -229,6 +242,8 @@ async def get_artists(
             query += f" AND a.sort_name ILIKE ${param_num} || '%'"
             params.append(starts_with)
             param_num += 1
+    if favorite_only:
+        query += " AND fav.user_id IS NOT NULL"
 
     query += (
         " ORDER BY LOWER(a.sort_name), a.sort_name"
@@ -281,6 +296,7 @@ async def get_artists(
             "primary_album_count": row["primary_album_count"],
             "appears_on_album_count": row["appears_on_album_count"],
             "listens": row["listens"],
+            "is_favorite": row["is_favorite"],
             "albums": [],  # Deprecated
             "background_sha1": sha1_to_hex(bg_info.get("art_sha1")),
         }
@@ -469,6 +485,7 @@ async def get_albums(
     artist: str = None,
     artist_mbid: str = None,
     album_mbid: str = None,
+    user: asyncpg.Record = Depends(get_current_user_jwt),
     db: asyncpg.Connection = Depends(get_db),
 ):
     # 1. If artist is provided, find their MBID to classify 'main' vs 'appears_on'
@@ -486,8 +503,8 @@ async def get_albums(
             -- Get only the albums we actually need first
             SELECT aa.album_mbid, aa.type, aa.artist_mbid
             FROM artist_album aa
-            WHERE ($1::text IS NULL OR aa.artist_mbid = $1)
-            AND ($2::text IS NULL OR aa.album_mbid = $2)
+            WHERE ($2::text IS NULL OR aa.artist_mbid = $2)
+            AND ($3::text IS NULL OR aa.album_mbid = $3)
         )
         SELECT
             al.title as album,
@@ -499,7 +516,7 @@ async def get_albums(
             fa.album_mbid,
             fa.album_mbid as mb_release_id,
             CASE 
-                WHEN $1 IS NOT NULL AND fa.type = 'contributor' THEN 'appears_on' 
+                WHEN $2 IS NOT NULL AND fa.type = 'contributor' THEN 'appears_on' 
                 ELSE 'main' 
             END as type,
             tr.track_count,
@@ -510,9 +527,12 @@ async def get_albums(
             ma.artists,
             art.sha1 AS art_sha1,
             lk.external_links,
-            ls.listens
+            ls.listens,
+            (fr.user_id IS NOT NULL) as is_favorite
         FROM filtered_albums fa
         JOIN album al ON fa.album_mbid = al.mbid
+        LEFT JOIN favorite_release fr
+            ON fr.album_mbid = al.mbid AND fr.user_id = $1
         -- Use LATERAL for track stats (avoids scanning the whole track table)
         LEFT JOIN LATERAL (
             SELECT 
@@ -551,7 +571,7 @@ async def get_albums(
     """
     
     # Execute
-    rows = await db.fetch(query, target_mbid, album_mbid)
+    rows = await db.fetch(query, user["id"], target_mbid, album_mbid)
     
     results = []
     for row in rows:

--- a/app/db.py
+++ b/app/db.py
@@ -271,6 +271,24 @@ async def init_db():
                 lastfm_enabled BOOLEAN DEFAULT TRUE,
                 lastfm_connected_at TIMESTAMPTZ
             );
+
+            CREATE TABLE IF NOT EXISTS favorite_artist (
+                user_id BIGINT NOT NULL,
+                artist_mbid TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                PRIMARY KEY (user_id, artist_mbid),
+                FOREIGN KEY(user_id) REFERENCES "user"(id) ON DELETE CASCADE,
+                FOREIGN KEY(artist_mbid) REFERENCES artist(mbid) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS favorite_release (
+                user_id BIGINT NOT NULL,
+                album_mbid TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                PRIMARY KEY (user_id, album_mbid),
+                FOREIGN KEY(user_id) REFERENCES "user"(id) ON DELETE CASCADE,
+                FOREIGN KEY(album_mbid) REFERENCES album(mbid) ON DELETE CASCADE
+            );
             
             -- Sessions
             CREATE TABLE IF NOT EXISTS session (
@@ -389,6 +407,14 @@ async def init_db():
             -- Session indexes
             CREATE INDEX IF NOT EXISTS idx_session_token ON session(token);
             CREATE INDEX IF NOT EXISTS idx_session_user ON session(user_id);
+            CREATE INDEX IF NOT EXISTS idx_favorite_artist_user_created
+                ON favorite_artist(user_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_favorite_artist_artist
+                ON favorite_artist(artist_mbid);
+            CREATE INDEX IF NOT EXISTS idx_favorite_release_user_created
+                ON favorite_release(user_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_favorite_release_album
+                ON favorite_release(album_mbid);
             
             -- Integrity & joins indexes
             CREATE INDEX IF NOT EXISTS idx_track_artwork ON track(artwork_id);

--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ from fastapi.staticfiles import StaticFiles  # noqa: E402
 from fastapi.responses import FileResponse  # noqa: E402
 from pathlib import Path  # noqa: E402
 from app.media import art  # noqa: E402
-from app.api import library, stream, player, search, scan, auth, media_quality, charts, lastfm, history, scheduler, recommendation  # noqa: E402
+from app.api import library, stream, player, search, scan, auth, media_quality, charts, lastfm, history, scheduler, recommendation, favorites  # noqa: E402
 from app import monitoring  # noqa: E402
 from app import playlist  # noqa: E402
 
@@ -85,6 +85,7 @@ app.include_router(history.router)
 app.include_router(scheduler.router)
 app.include_router(recommendation.router, prefix="/api")
 app.include_router(monitoring.router)
+app.include_router(favorites.router)
 
 
 # Serve built SvelteKit frontend (output lives in web/build)

--- a/dev.sh
+++ b/dev.sh
@@ -29,7 +29,6 @@ echo "Changes to frontend or backend code will auto-reload!"
 echo "No Docker rebuilds needed! 🎉"
 echo ""
 
-
 # Check for dependency changes
 DEP_HASH_FILE=".deps.sha256"
 # Calculate hash of pyproject.toml and uv.lock (if it exists)
@@ -50,8 +49,15 @@ else
   echo "✨ Dependencies unchanged, skipping build."
 fi
 
-# Start services in detached mode
+# Stop existing containers before clearing generated frontend state.
 docker compose down
+
+# Clear generated frontend caches so route graph changes cannot leave
+# stale .svelte-kit / Vite artifacts behind across dev restarts.
+echo "🧽 Clearing frontend dev caches..."
+rm -rf web/.svelte-kit web/.vite
+
+# Start services in detached mode
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 echo ""

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,10 +31,15 @@ services:
       - ./web:/app/web
       # Use named volume for node_modules to avoid conflicts with host
       - jamarr_web_node_modules:/app/web/node_modules
-    entrypoint: /bin/sh -c "npm install && npm run dev:host"
+      # Keep generated dev artifacts inside Docker-owned volumes
+      - jamarr_web_svelte_kit:/app/web/.svelte-kit
+      - jamarr_web_vite_cache:/app/web/.vite
+    entrypoint: /bin/sh -c "npm install && npx svelte-kit sync && npm run dev:host -- --force"
     environment:
       - VITE_API_URL=http://127.0.0.1:8111
     restart: unless-stopped
 
 volumes:
   jamarr_web_node_modules:
+  jamarr_web_svelte_kit:
+  jamarr_web_vite_cache:

--- a/scripts/migrations/028_user_favorites.sql
+++ b/scripts/migrations/028_user_favorites.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS favorite_artist (
+    user_id BIGINT NOT NULL,
+    artist_mbid TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (user_id, artist_mbid),
+    FOREIGN KEY(user_id) REFERENCES "user"(id) ON DELETE CASCADE,
+    FOREIGN KEY(artist_mbid) REFERENCES artist(mbid) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS favorite_release (
+    user_id BIGINT NOT NULL,
+    album_mbid TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (user_id, album_mbid),
+    FOREIGN KEY(user_id) REFERENCES "user"(id) ON DELETE CASCADE,
+    FOREIGN KEY(album_mbid) REFERENCES album(mbid) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_artist_user_created
+    ON favorite_artist(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_artist_artist
+    ON favorite_artist(artist_mbid);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_release_user_created
+    ON favorite_release(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_release_album
+    ON favorite_release(album_mbid);

--- a/tests/api/test_favorites.py
+++ b/tests/api/test_favorites.py
@@ -1,0 +1,124 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture
+async def favorite_data(db):
+    await db.execute(
+        """
+        INSERT INTO artist (mbid, name, sort_name, letter)
+        VALUES ('artist-fav-1', 'Favorite Artist', 'Favorite Artist', 'F')
+        """
+    )
+    await db.execute(
+        """
+        INSERT INTO album (mbid, release_group_mbid, title, release_date)
+        VALUES ('release-fav-1', 'release-group-fav-1', 'Favorite Release', '2024-01-01')
+        """
+    )
+
+
+@pytest.mark.asyncio
+async def test_toggle_artist_favorite(auth_client: AsyncClient, db, favorite_data):
+    user = await db.fetchrow('SELECT id FROM "user" WHERE username = $1', "testuser")
+
+    response = await auth_client.put(
+        "/api/favorites/artists/artist-fav-1",
+        json={"favorite": True},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"artist_mbid": "artist-fav-1", "favorite": True}
+
+    favorite = await db.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM favorite_artist
+        WHERE user_id = $1 AND artist_mbid = $2
+        """,
+        user["id"],
+        "artist-fav-1",
+    )
+    assert favorite == 1
+
+    response = await auth_client.put(
+        "/api/favorites/artists/artist-fav-1",
+        json={"favorite": False},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"artist_mbid": "artist-fav-1", "favorite": False}
+
+    favorite = await db.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM favorite_artist
+        WHERE user_id = $1 AND artist_mbid = $2
+        """,
+        user["id"],
+        "artist-fav-1",
+    )
+    assert favorite == 0
+
+
+@pytest.mark.asyncio
+async def test_toggle_release_favorite_is_user_scoped(
+    auth_client: AsyncClient, db, favorite_data
+):
+    current_user = await db.fetchrow('SELECT id FROM "user" WHERE username = $1', "testuser")
+    other_user = await db.fetchrow(
+        """
+        INSERT INTO "user" (username, email, password_hash, display_name, created_at)
+        VALUES ('favorite_other_user', 'favorite_other_user@example.com', 'hash', 'Favorite Other User', NOW())
+        RETURNING id
+        """
+    )
+    await db.execute(
+        "INSERT INTO favorite_release (user_id, album_mbid) VALUES ($1, $2)",
+        other_user["id"],
+        "release-fav-1",
+    )
+
+    response = await auth_client.put(
+        "/api/favorites/releases/release-fav-1",
+        json={"favorite": True},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"album_mbid": "release-fav-1", "favorite": True}
+
+    current_count = await db.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM favorite_release
+        WHERE user_id = $1 AND album_mbid = $2
+        """,
+        current_user["id"],
+        "release-fav-1",
+    )
+    other_count = await db.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM favorite_release
+        WHERE user_id = $1 AND album_mbid = $2
+        """,
+        other_user["id"],
+        "release-fav-1",
+    )
+
+    assert current_count == 1
+    assert other_count == 1
+
+
+@pytest.mark.asyncio
+async def test_toggle_favorite_returns_404_for_unknown_entity(
+    auth_client: AsyncClient, favorite_data
+):
+    response = await auth_client.put(
+        "/api/favorites/artists/not-found",
+        json={"favorite": True},
+    )
+    assert response.status_code == 404
+
+    response = await auth_client.put(
+        "/api/favorites/releases/not-found",
+        json={"favorite": True},
+    )
+    assert response.status_code == 404

--- a/tests/api/test_library.py
+++ b/tests/api/test_library.py
@@ -81,6 +81,7 @@ async def test_get_artists(auth_client: AsyncClient, db, library_data):
     # Verify artwork fields logic
     tester = next(a for a in data if a["name"] == "The Testers")
     assert tester["art_sha1"] == '1111111111222222222233333333334444444444'
+    assert tester["is_favorite"] is False
 
     # 2. Filter by name
     response = await auth_client.get("/api/artists", params={"name": "The Testers"})
@@ -110,11 +111,43 @@ async def test_get_artists_lightweight_starts_with(auth_client: AsyncClient, db,
     assert "top_tracks" not in data[0]
     assert "primary_album_count" in data[0]
     assert "appears_on_album_count" in data[0]
+    assert data[0]["is_favorite"] is False
 
     response = await auth_client.get("/api/artists", params={"starts_with": "#"})
     data = response.json()
     assert len(data) == 1
     assert data[0]["name"] == "123 Band"
+
+
+@pytest.mark.asyncio
+async def test_get_artists_favorite_only_filters_for_current_user(
+    auth_client: AsyncClient, db, library_data
+):
+    current_user = await db.fetchrow('SELECT id FROM "user" WHERE username = $1', "testuser")
+    other_user = await db.fetchrow(
+        """
+        INSERT INTO "user" (username, email, password_hash, display_name, created_at)
+        VALUES ('otheruser', 'otheruser@example.com', 'hash', 'Other User', NOW())
+        RETURNING id
+        """
+    )
+
+    await db.execute(
+        "INSERT INTO favorite_artist (user_id, artist_mbid) VALUES ($1, $2)",
+        current_user["id"],
+        "artist-1",
+    )
+    await db.execute(
+        "INSERT INTO favorite_artist (user_id, artist_mbid) VALUES ($1, $2)",
+        other_user["id"],
+        "artist-2",
+    )
+
+    response = await auth_client.get("/api/artists", params={"favorite_only": "true"})
+    assert response.status_code == 200
+    data = response.json()
+    assert [artist["name"] for artist in data] == ["The Testers"]
+    assert data[0]["is_favorite"] is True
 
 @pytest.mark.asyncio
 async def test_get_albums(auth_client: AsyncClient, db, library_data):
@@ -136,6 +169,7 @@ async def test_get_albums(auth_client: AsyncClient, db, library_data):
         "aaaaabbbbbcccccdddddeeeeefffff1111122222",
         None,
     }
+    assert test_album["is_favorite"] is False
     
     # 2. Filter by Artist
     response = await auth_client.get("/api/albums", params={"artist": "The Testers"})
@@ -222,6 +256,25 @@ async def test_get_albums_details(auth_client: AsyncClient, db, library_data):
     assert test_album["external_links"] is None or isinstance(
         test_album["external_links"], list
     )
+
+
+@pytest.mark.asyncio
+async def test_get_albums_includes_user_favorite_state(
+    auth_client: AsyncClient, db, library_data
+):
+    current_user = await db.fetchrow('SELECT id FROM "user" WHERE username = $1', "testuser")
+    await db.execute(
+        "INSERT INTO favorite_release (user_id, album_mbid) VALUES ($1, $2)",
+        current_user["id"],
+        "release-1",
+    )
+
+    response = await auth_client.get("/api/albums", params={"album_mbid": "release-1"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["album"] == "Test Album"
+    assert data[0]["is_favorite"] is True
 
 @pytest.mark.asyncio
 async def test_get_tracks(auth_client: AsyncClient, db, library_data):

--- a/tests/auth/test_migration_028.py
+++ b/tests/auth/test_migration_028.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+import asyncpg
+
+from app.auth import hash_password
+from scripts.apply_migrations import _split_statements
+
+
+@pytest.mark.asyncio
+async def test_migration_028_creates_user_favorite_tables(db: asyncpg.Connection):
+    migration = Path("scripts/migrations/028_user_favorites.sql")
+    statements = _split_statements(migration.read_text())
+
+    tx = db.transaction()
+    await tx.start()
+    try:
+        await db.execute(
+            """
+            INSERT INTO "user" (username, email, password_hash, display_name, created_at)
+            VALUES ('fav_migration_user', 'fav_migration_user@example.com', $1, 'Fav Migration User', NOW())
+            ON CONFLICT (username) DO NOTHING
+            """,
+            hash_password("password123"),
+        )
+        await db.execute(
+            """
+            INSERT INTO artist (mbid, name, sort_name, letter)
+            VALUES ('migration-artist', 'Migration Artist', 'Migration Artist', 'M')
+            ON CONFLICT (mbid) DO NOTHING
+            """
+        )
+        await db.execute(
+            """
+            INSERT INTO album (mbid, release_group_mbid, title, release_date)
+            VALUES ('migration-release', 'migration-rg', 'Migration Release', '2024-01-01')
+            ON CONFLICT (mbid) DO NOTHING
+            """
+        )
+
+        for statement in statements:
+            await db.execute(statement)
+
+        user = await db.fetchrow(
+            'SELECT id FROM "user" WHERE username = $1',
+            "fav_migration_user",
+        )
+        await db.execute(
+            """
+            INSERT INTO favorite_artist (user_id, artist_mbid)
+            VALUES ($1, $2)
+            """,
+            user["id"],
+            "migration-artist",
+        )
+        await db.execute(
+            """
+            INSERT INTO favorite_release (user_id, album_mbid)
+            VALUES ($1, $2)
+            """,
+            user["id"],
+            "migration-release",
+        )
+
+        artist_favorite = await db.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM favorite_artist
+            WHERE user_id = $1 AND artist_mbid = $2
+            """,
+            user["id"],
+            "migration-artist",
+        )
+        release_favorite = await db.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM favorite_release
+            WHERE user_id = $1 AND album_mbid = $2
+            """,
+            user["id"],
+            "migration-release",
+        )
+
+        assert artist_favorite == 1
+        assert release_favorite == 1
+    finally:
+        await tx.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,8 @@ async def db() -> AsyncGenerator[asyncpg.Connection, None]:
             "lastfm_skip_artist",
             "track_artist",
             "artist_album",
+            "favorite_artist",
+            "favorite_release",
         ]
         truncate = [t for t in tables if t in existing]
         if truncate:

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -6,6 +6,7 @@ export interface Artist {
     image_url: string | null;
     art_sha1?: string | null;
     background_sha1?: string | null;
+    is_favorite?: boolean;
     bio: string | null;
     similar_artists: {
         name: string;
@@ -88,6 +89,7 @@ export interface Album {
     mbid?: string;
     album_mbid?: string;
     art_sha1?: string | null;
+    is_favorite?: boolean;
     artist_name: string;
     artist_mbid?: string;
     is_hires: number;
@@ -210,7 +212,14 @@ export async function fetchWithAuth(
 
 export async function fetchArtists(
     fetchFn: any = fetchWithAuth,
-    options: { limit?: number; offset?: number; name?: string; mbid?: string, startsWith?: string } = {}
+    options: {
+        limit?: number;
+        offset?: number;
+        name?: string;
+        mbid?: string;
+        startsWith?: string;
+        favoriteOnly?: boolean;
+    } = {}
 ): Promise<Artist[]> {
     const params = new URLSearchParams();
     if (options.limit !== undefined) params.append('limit', options.limit.toString());
@@ -218,6 +227,7 @@ export async function fetchArtists(
     if (options.name !== undefined) params.append('name', options.name);
     if (options.mbid !== undefined) params.append('mbid', options.mbid);
     if (options.startsWith !== undefined) params.append('starts_with', options.startsWith);
+    if (options.favoriteOnly) params.append('favorite_only', 'true');
 
     const res = await fetchFn(`/api/artists?${params.toString()}`);
     if (!res.ok) throw new Error('Failed to fetch artists');
@@ -252,6 +262,24 @@ export async function fetchAlbums(params: { artist?: string; artistMbid?: string
     const res = await fetchFn(url);
     if (!res.ok) throw new Error('Failed to fetch albums');
     return await res.json();
+}
+
+export async function setArtistFavorite(artistMbid: string, favorite: boolean): Promise<void> {
+    const res = await fetchWithAuth(`/api/favorites/artists/${encodeURIComponent(artistMbid)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ favorite })
+    });
+    if (!res.ok) throw new Error('Failed to update artist favorite');
+}
+
+export async function setReleaseFavorite(albumMbid: string, favorite: boolean): Promise<void> {
+    const res = await fetchWithAuth(`/api/favorites/releases/${encodeURIComponent(albumMbid)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ favorite })
+    });
+    if (!res.ok) throw new Error('Failed to update release favorite');
 }
 
 export async function fetchTracks(params: { album?: string, artist?: string, albumMbid?: string } = {}, fetchFn: any = fetchWithAuth): Promise<Track[]> {

--- a/web/src/routes/album/[id]/+page.svelte
+++ b/web/src/routes/album/[id]/+page.svelte
@@ -6,11 +6,12 @@
   import IconButton from "$components/IconButton.svelte";
   import TrackCard from "$components/TrackCard.svelte";
   import { downloadTracks } from "$lib/helpers/downloader";
-  import { getArtUrl } from "$lib/api";
+  import { getArtUrl, setReleaseFavorite } from "$lib/api";
 
   let showPlaylistModal = false;
   let selectedTrackIds: number[] = [];
   let isDescriptionExpanded = false;
+  let favoritePending = false;
 
   function openPlaylistModal(trackId: number) {
     selectedTrackIds = [trackId];
@@ -23,6 +24,36 @@
     tracks: Track[];
     albumMeta?: Album;
   };
+
+  async function toggleAlbumFavorite() {
+    const albumMbid = data.albumMeta?.album_mbid || data.albumMeta?.mb_release_id;
+    if (!albumMbid || favoritePending || !data.albumMeta) return;
+
+    const nextFavorite = !data.albumMeta.is_favorite;
+    favoritePending = true;
+    data = {
+      ...data,
+      albumMeta: {
+        ...data.albumMeta,
+        is_favorite: nextFavorite,
+      },
+    };
+
+    try {
+      await setReleaseFavorite(albumMbid, nextFavorite);
+    } catch (e) {
+      console.error("Failed to update release favorite", e);
+      data = {
+        ...data,
+        albumMeta: {
+          ...data.albumMeta,
+          is_favorite: !nextFavorite,
+        },
+      };
+    } finally {
+      favoritePending = false;
+    }
+  }
 
   // Reactive album art URL - recalculates when data changes
   $: albumArtUrl = (() => {
@@ -235,11 +266,38 @@
         <!-- Album details -->
         <div class="space-y-4">
           <div>
-            <h1
-              class="text-3xl font-bold tracking-tight text-default leading-tight sm:text-4xl md:text-5xl"
-            >
-              {data.album}
-            </h1>
+            <div class="flex items-start gap-3">
+              <h1
+                class="min-w-0 text-3xl font-bold tracking-tight text-default leading-tight sm:text-4xl md:text-5xl"
+              >
+                {data.album}
+              </h1>
+              {#if data.albumMeta?.album_mbid || data.albumMeta?.mb_release_id}
+                <IconButton
+                  variant={data.albumMeta?.is_favorite ? "primary" : "outline"}
+                  title={data.albumMeta?.is_favorite ? "Remove release favorite" : "Favorite release"}
+                  onClick={toggleAlbumFavorite}
+                  className={`shrink-0 ${
+                    data.albumMeta?.is_favorite
+                      ? "border-rose-500 bg-rose-500 text-white hover:bg-rose-400"
+                      : "border-subtle bg-surface-2 text-default hover:bg-surface-3"
+                  } ${favoritePending ? "opacity-70" : ""}`}
+                >
+                  <svg
+                    class={`h-5 w-5 ${data.albumMeta?.is_favorite ? "fill-current" : "fill-none"}`}
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M12 21s-6.716-4.31-9.193-8.115C1.09 10.25 1.81 6.91 4.68 5.526c1.9-.916 4.154-.468 5.78 1.147L12 8.213l1.54-1.54c1.626-1.615 3.88-2.063 5.78-1.147 2.87 1.384 3.59 4.724 1.873 7.359C18.716 16.69 12 21 12 21z"
+                    />
+                  </svg>
+                </IconButton>
+              {/if}
+            </div>
             <div class="mt-2 text-lg font-medium text-muted sm:text-xl md:text-2xl">
               {#if data.albumMeta?.artists && data.albumMeta.artists.length > 0}
                 {#each data.albumMeta.artists as artist, i}

--- a/web/src/routes/artist/[id]/+page.svelte
+++ b/web/src/routes/artist/[id]/+page.svelte
@@ -8,6 +8,7 @@
     triggerPearlarrDownload,
     getArtUrl,
     getPlaylist,
+    setArtistFavorite,
   } from "$lib/api";
   import { goto, invalidateAll } from "$app/navigation";
   import IconButton from "$components/IconButton.svelte";
@@ -59,6 +60,25 @@
   let scanningMissing = false;
   // Pearlarr State
   let downloadingMbids = new Set<string>();
+  let favoritePending = false;
+
+  async function toggleArtistFavorite() {
+    if (!artist?.mbid || favoritePending) return;
+
+    const nextFavorite = !artist.is_favorite;
+    favoritePending = true;
+    artist = { ...artist, is_favorite: nextFavorite };
+
+    try {
+      await setArtistFavorite(artist.mbid, nextFavorite);
+    } catch (e) {
+      console.error("Failed to update artist favorite", e);
+      artist = { ...artist, is_favorite: !nextFavorite };
+      message = "Failed to update favorite";
+    } finally {
+      favoritePending = false;
+    }
+  }
 
   async function downloadAlbum(mbid: string) {
     if (downloadingMbids.has(mbid)) return;
@@ -118,7 +138,7 @@
   }
 
   // Update artist when route data changes (client nav)
-  $: if (data.artist !== artist) {
+  $: if (data.artist && data.artist.mbid !== artist?.mbid) {
     artist = data.artist;
   }
   $: if (data.playlists !== playlists) {
@@ -839,11 +859,38 @@
     <!-- Hero Content -->
     <div class="absolute inset-0 flex items-end px-4 pb-8 md:px-12 md:pb-12 xl:px-16">
       <div class="w-full space-y-2">
-        <h1
-          class="text-4xl font-bold tracking-tight text-white drop-shadow-2xl sm:text-5xl md:text-8xl lg:text-9xl"
-        >
-          {artist?.name ?? data.name}
-        </h1>
+        <div class="flex items-end gap-3 md:gap-4">
+          <h1
+            class="min-w-0 text-4xl font-bold tracking-tight text-white drop-shadow-2xl sm:text-5xl md:text-8xl lg:text-9xl"
+          >
+            {artist?.name ?? data.name}
+          </h1>
+          {#if artist?.mbid}
+            <IconButton
+              variant={artist.is_favorite ? "primary" : "outline"}
+              title={artist.is_favorite ? "Remove artist favorite" : "Favorite artist"}
+              onClick={toggleArtistFavorite}
+              className={`mb-1 shrink-0 border-white/30 ${
+                artist.is_favorite
+                  ? "bg-rose-500 text-white hover:bg-rose-400"
+                  : "bg-black/20 text-white hover:bg-black/35"
+              } ${favoritePending ? "opacity-70" : ""}`}
+            >
+              <svg
+                class={`h-5 w-5 md:h-6 md:w-6 ${artist.is_favorite ? "fill-current" : "fill-none"}`}
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 21s-6.716-4.31-9.193-8.115C1.09 10.25 1.81 6.91 4.68 5.526c1.9-.916 4.154-.468 5.78 1.147L12 8.213l1.54-1.54c1.626-1.615 3.88-2.063 5.78-1.147 2.87 1.384 3.59 4.724 1.873 7.359C18.716 16.69 12 21 12 21z"
+                />
+              </svg>
+            </IconButton>
+          {/if}
+        </div>
         {#if artist?.genres?.length}
           <div class="flex flex-wrap gap-2 text-sm font-medium text-white/70 sm:text-base md:text-lg">
             {artist.genres.map((g) => g.name).join(" · ")}

--- a/web/src/routes/artists/+page.svelte
+++ b/web/src/routes/artists/+page.svelte
@@ -4,11 +4,17 @@
   import { goto } from "$app/navigation";
   import TabButton from "$lib/components/TabButton.svelte";
 
-  export let data: { artists: Artist[]; start: string; index: string[] };
+  export let data: {
+    artists: Artist[];
+    start: string;
+    index: string[];
+    favoriteOnly?: boolean;
+  };
 
   let artists: Artist[] = data.artists;
 
   let showAllArtists = false;
+  let showFavoriteArtists = false;
   let visibleArtists: Artist[] = artists;
   let activeFilter = data.start;
 
@@ -17,6 +23,7 @@
   $: {
     artists = data.artists;
     activeFilter = data.start;
+    showFavoriteArtists = !!data.favoriteOnly;
 
     const idx = data.index || [];
     const hasHash = idx.includes("#");
@@ -38,8 +45,21 @@
     ? artists
     : artists.filter(isPrimaryArtist);
 
+  function buildQuery(filter: string, favoriteOnly = showFavoriteArtists) {
+    const params = new URLSearchParams();
+    params.set("start", filter);
+    if (favoriteOnly) {
+      params.set("favorite_only", "1");
+    }
+    return `?${params.toString()}`;
+  }
+
   function handleFilterClick(filter: string) {
-    goto(`?start=${filter}`, { keepFocus: true });
+    goto(buildQuery(filter), { keepFocus: true });
+  }
+
+  function toggleFavoriteFilter() {
+    goto(buildQuery(activeFilter, !showFavoriteArtists), { keepFocus: true });
   }
 </script>
 
@@ -71,7 +91,32 @@
       </div>
 
       <!-- RIGHT: Primary / All -->
-      <div class="flex justify-end whitespace-nowrap">
+      <div class="flex justify-end whitespace-nowrap gap-3">
+        <button
+          type="button"
+          class={`inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors ${
+            showFavoriteArtists
+              ? "border-rose-500/50 bg-rose-500/15 text-default"
+              : "border-subtle bg-surface-2 text-muted hover:text-default"
+          }`}
+          on:click={toggleFavoriteFilter}
+          aria-pressed={showFavoriteArtists}
+          title={showFavoriteArtists ? "Show all artists" : "Show favorite artists only"}
+        >
+          <svg
+            class={`h-4 w-4 ${showFavoriteArtists ? "fill-rose-500 text-rose-500" : "fill-none text-current"}`}
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.8"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 21s-6.716-4.31-9.193-8.115C1.09 10.25 1.81 6.91 4.68 5.526c1.9-.916 4.154-.468 5.78 1.147L12 8.213l1.54-1.54c1.626-1.615 3.88-2.063 5.78-1.147 2.87 1.384 3.59 4.724 1.873 7.359C18.716 16.69 12 21 12 21z"
+            />
+          </svg>
+          <span>Favorites</span>
+        </button>
         <div class="flex bg-surface-2 rounded-lg p-1 gap-1">
           <TabButton
             active={!showAllArtists}
@@ -146,13 +191,42 @@
           </div>
         </div>
       </div>
+
+      <button
+        type="button"
+        class={`inline-flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3 text-sm font-medium transition-colors ${
+          showFavoriteArtists
+            ? "border-rose-500/50 bg-rose-500/15 text-default"
+            : "border-subtle bg-surface-2 text-muted"
+        }`}
+        on:click={toggleFavoriteFilter}
+        aria-pressed={showFavoriteArtists}
+      >
+        <svg
+          class={`h-4 w-4 ${showFavoriteArtists ? "fill-rose-500 text-rose-500" : "fill-none text-current"}`}
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 21s-6.716-4.31-9.193-8.115C1.09 10.25 1.81 6.91 4.68 5.526c1.9-.916 4.154-.468 5.78 1.147L12 8.213l1.54-1.54c1.626-1.615 3.88-2.063 5.78-1.147 2.87 1.384 3.59 4.724 1.873 7.359C18.716 16.69 12 21 12 21z"
+          />
+        </svg>
+        <span>{showFavoriteArtists ? "Showing Favorites" : "Show Favorites Only"}</span>
+      </button>
     </div>
   </div>
 
   <div class="flex flex-col gap-10">
     {#if visibleArtists.length === 0}
       <div class="text-muted text-lg italic py-10 text-center">
-        No artists found starting with "{activeFilter}"
+        {#if showFavoriteArtists}
+          No favorite artists found.
+        {:else}
+          No artists found starting with "{activeFilter}"
+        {/if}
         {#if !showAllArtists}
           <br />
           <span class="text-sm"

--- a/web/src/routes/artists/+page.ts
+++ b/web/src/routes/artists/+page.ts
@@ -4,14 +4,15 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, url }) => {
   const start = url.searchParams.get('start') || '#';
+  const favoriteOnly = url.searchParams.get('favorite_only') === '1';
   const authFetch = (input: RequestInfo | URL, init?: RequestInit) =>
     fetchWithAuth(String(input), init, fetch);
 
   // Parallel fetch: artists for current view + available letters index
   const [artists, index] = await Promise.all([
-    fetchArtists(authFetch, { startsWith: start }),
+    fetchArtists(authFetch, favoriteOnly ? { favoriteOnly: true } : { startsWith: start }),
     fetchArtistIndex(authFetch)
   ]);
 
-  return { artists, start, index };
+  return { artists, start, index, favoriteOnly };
 };


### PR DESCRIPTION
## Summary
- add per-user artist and release favorites with a safe additive database migration
- expose favorite state and toggle endpoints in the API and surface it on artist and album pages
- add a favorites-only filter on the artists page and fix artist-page UI reactivity after toggling
- stabilize the dev frontend startup by isolating SvelteKit and Vite generated state in Docker volumes

## Migration safety
- migration 028_user_favorites.sql is additive only
- uses CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS
- does not modify or delete existing users, artists, albums, or favorites data

## Verification
- npm run check
- ./test.sh tests/auth/test_migration_028.py tests/api/test_favorites.py tests/api/test_library.py
