### PR TITLE
Add list endpoints for favourite artists and releases

### DIFF
--- a/app/api/favorites.py
+++ b/app/api/favorites.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from app.api.deps import get_current_user_jwt
+from app.api.library import sha1_to_hex
 from app.db import get_db
 
 
@@ -15,6 +16,80 @@ router = APIRouter(
 
 class FavoriteToggleRequest(BaseModel):
     favorite: bool
+
+
+@router.get("/artists")
+async def list_favorite_artists(
+    user: asyncpg.Record = Depends(get_current_user_jwt),
+    db: asyncpg.Connection = Depends(get_db),
+):
+    rows = await db.fetch(
+        """
+        SELECT
+            a.mbid,
+            a.name,
+            ar.sha1 AS art_sha1,
+            COALESCE(lp.listens, 0) AS listens,
+            f.created_at
+        FROM favorite_artist f
+        JOIN artist a ON a.mbid = f.artist_mbid
+        LEFT JOIN artwork ar ON a.artwork_id = ar.id
+        LEFT JOIN LATERAL (
+            SELECT COUNT(h.source_id) AS listens
+            FROM track_artist ta
+            JOIN combined_playback_history_mat h ON h.track_id = ta.track_id
+            WHERE ta.artist_mbid = a.mbid
+        ) lp ON TRUE
+        WHERE f.user_id = $1
+        ORDER BY f.created_at DESC
+        """,
+        user["id"],
+    )
+    return [
+        {
+            "mbid": r["mbid"],
+            "name": r["name"],
+            "art_sha1": sha1_to_hex(r["art_sha1"]),
+            "listens": r["listens"],
+        }
+        for r in rows
+    ]
+
+
+@router.get("/releases")
+async def list_favorite_releases(
+    user: asyncpg.Record = Depends(get_current_user_jwt),
+    db: asyncpg.Connection = Depends(get_db),
+):
+    rows = await db.fetch(
+        """
+        SELECT
+            al.mbid AS album_mbid,
+            al.title,
+            COALESCE(MAX(t.album_artist), MAX(t.artist)) AS artist_name,
+            al.release_date,
+            ar.sha1 AS art_sha1,
+            f.created_at
+        FROM favorite_release f
+        JOIN album al ON al.mbid = f.album_mbid
+        LEFT JOIN artwork ar ON al.artwork_id = ar.id
+        LEFT JOIN track t ON t.release_mbid = al.mbid
+        WHERE f.user_id = $1
+        GROUP BY al.mbid, al.title, al.release_date, ar.sha1, f.created_at
+        ORDER BY f.created_at DESC
+        """,
+        user["id"],
+    )
+    return [
+        {
+            "album_mbid": r["album_mbid"],
+            "title": r["title"],
+            "artist_name": r["artist_name"],
+            "year": r["release_date"],
+            "art_sha1": sha1_to_hex(r["art_sha1"]),
+        }
+        for r in rows
+    ]
 
 
 async def _ensure_exists(


### PR DESCRIPTION
## Summary
- Adds `GET /api/favorites/artists` returning the current user's favourite artists with `mbid`, `name`, `art_sha1`, and `listens`, ordered by `created_at DESC`.
- Adds `GET /api/favorites/releases` returning the current user's favourite albums with `album_mbid`, `title`, `artist_name`, `year`, and `art_sha1`, ordered by `created_at DESC`.
- Needed to back the new Favourites tab in the Android app (separate PR), which can't be implemented with the existing `/api/artists?favorite_only=true` endpoint alone (no album equivalent, no created-order).

## Test plan
- [ ] \`curl -H "Authorization: Bearer …" \$HOST/api/favorites/artists\` returns favourites in most-recent-first order.
- [ ] \`curl -H "Authorization: Bearer …" \$HOST/api/favorites/releases\` returns favourites in most-recent-first order.
- [ ] Existing \`PUT /api/favorites/artists/{mbid}\` and \`PUT /api/favorites/releases/{mbid}\` still work (no behavioural changes).
- [ ] Web UI unaffected (it doesn't call the new GETs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)