### PR TITLE
Replace hardcoded admin with first-run setup flow

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         versionCode = 1
         versionName = "0.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "DEFAULT_SERVER_URL", "\"https://jamarr.darious.co.uk\"")
+        buildConfigField("String", "DEFAULT_SERVER_URL", "\"http://10.0.2.2:8111\"")
     }
 
     signingConfigs {

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -450,7 +450,7 @@ async def update_preferences(
             )
         updates.append(f"theme_mode = ${len(values) + 1}")
         values.append(payload.theme_mode)
-        
+
     if updates:
         values.append(user["id"])
         await db.execute(
@@ -462,3 +462,86 @@ async def update_preferences(
         user["id"],
     )
     return _public_user_dict(updated_user or user)
+
+
+class SetupBody(BaseModel):
+    username: str
+    email: EmailStr
+    password: str
+    display_name: Optional[str] = None
+
+
+@router.get("/api/auth/setup-status")
+async def setup_status(db: asyncpg.Connection = Depends(get_db)):
+    count = await db.fetchval('SELECT COUNT(*) FROM "user"')
+    return {"setup_required": count == 0}
+
+
+@router.post("/api/auth/setup", status_code=status.HTTP_201_CREATED)
+async def setup_first_user(
+    request: Request,
+    response: Response,
+    payload: SetupBody,
+    db: asyncpg.Connection = Depends(get_db),
+):
+    _validate_password(payload.password)
+
+    username = payload.username.strip()
+    email = payload.email.strip()
+    password_hash = hash_password(payload.password)
+    display_name = payload.display_name.strip() if payload.display_name else None
+
+    async with db.transaction():
+        # Serialize concurrent setup attempts within the same transaction
+        await db.execute("SELECT pg_advisory_xact_lock(997342)")
+
+        user = await db.fetchrow(
+            """
+            INSERT INTO "user" (username, email, password_hash, display_name, is_admin, created_at)
+            SELECT $1, $2, $3, $4, TRUE, NOW()
+            WHERE NOT EXISTS (SELECT 1 FROM "user")
+            RETURNING *
+            """,
+            username,
+            email,
+            password_hash,
+            display_name,
+        )
+
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Setup has already been completed. A user already exists.",
+            )
+
+        access_token = create_access_token(user_id=user["id"])
+
+        refresh_token = generate_refresh_token()
+        refresh_token_hash = hash_refresh_token(refresh_token)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_TTL_DAYS)
+
+        await create_refresh_session(
+            db=db,
+            user_id=user["id"],
+            token_hash=refresh_token_hash,
+            expires_at=expires_at,
+            user_agent=request.headers.get("user-agent"),
+            ip=get_client_ip(request),
+        )
+
+    log_security_event(
+        "setup_completed",
+        request,
+        level=logging.INFO,
+        user_id=user["id"],
+        username=user["username"],
+    )
+
+    _set_refresh_cookie(response, refresh_token)
+
+    user_data = _public_user_dict(user)
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": user_data,
+    }

--- a/app/db.py
+++ b/app/db.py
@@ -465,10 +465,6 @@ async def init_db():
         await conn.execute("""
             ALTER TABLE "user"
             ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
-
-            UPDATE "user"
-            SET is_admin = TRUE
-            WHERE username = 'chris';
         """)
 
         # Create FTS trigger function

--- a/docs/android.md
+++ b/docs/android.md
@@ -707,7 +707,7 @@ Implementation details:
 
   ```json
   {
-    "username": "chris",
+    "username": "your_username",
     "password": "..."
   }
   ```

--- a/migrations/027_user_admin_flag.sql
+++ b/migrations/027_user_admin_flag.sql
@@ -1,14 +1,6 @@
 ALTER TABLE "user"
 ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
 
-UPDATE "user"
-SET is_admin = FALSE
-WHERE username <> 'chris';
-
-UPDATE "user"
-SET is_admin = TRUE
-WHERE username = 'chris';
-
 ALTER TABLE "user"
 ALTER COLUMN is_admin SET DEFAULT FALSE;
 

--- a/scripts/demo-jwt-auth.sh
+++ b/scripts/demo-jwt-auth.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-BASE_URL="http://REDACTED_IP:8111"
+BASE_URL="${JAMARR_URL:-http://localhost:8111}"
 COOKIES_FILE="/tmp/jamarr_cookies.txt"
 
 echo "=========================================="
@@ -20,7 +20,7 @@ echo "Step 1: Login with username/password"
 echo "--------------------------------------"
 LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
   -H "Content-Type: application/json" \
-  -d '{"username":"chris","password":"sld23mxg"}' \
+  -d '{"username":"YOUR_USERNAME","password":"YOUR_PASSWORD"}' \
   -c "$COOKIES_FILE" \
   -w "\n%{http_code}")
 

--- a/scripts/lastfm/match-lastfm.py
+++ b/scripts/lastfm/match-lastfm.py
@@ -1298,7 +1298,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Match Last.fm scrobbles to library tracks using local data.",
     )
-    parser.add_argument("--user", default="darious1472", help="Last.fm username")
+    parser.add_argument("--user", default=os.getenv("LASTFM_USERNAME", ""), help="Last.fm username")
     parser.add_argument("--limit", type=int, default=200, help="Scrobbles to match")
     parser.add_argument(
         "--dry-run",

--- a/scripts/lastfm/pull-lastfm.py
+++ b/scripts/lastfm/pull-lastfm.py
@@ -426,7 +426,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Pull Last.fm scrobble history and store in dev DB.",
     )
-    parser.add_argument("--user", default="darious1472", help="Last.fm username")
+    parser.add_argument("--user", default=os.getenv("LASTFM_USERNAME", ""), help="Last.fm username")
     parser.add_argument("--limit", type=int, default=200, help="Tracks per page")
     parser.add_argument("--max-pages", type=int, default=0, help="Stop after N pages")
     parser.add_argument(

--- a/scripts/lastfm/review-lastfm.py
+++ b/scripts/lastfm/review-lastfm.py
@@ -252,7 +252,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Review and confirm Last.fm match candidates.",
     )
-    parser.add_argument("--user", default="darious1472", help="Last.fm username")
+    parser.add_argument("--user", default=os.getenv("LASTFM_USERNAME", ""), help="Last.fm username")
     parser.add_argument(
         "--auto-pass",
         action="store_true",

--- a/tests/auth/test_api_setup.py
+++ b/tests/auth/test_api_setup.py
@@ -1,0 +1,132 @@
+"""Integration tests for setup-status and setup endpoints."""
+import pytest
+from httpx import AsyncClient
+import asyncpg
+
+
+@pytest.mark.asyncio
+async def test_setup_status_required_when_empty(client: AsyncClient, db: asyncpg.Connection):
+    """setup-status returns setup_required: true when no users exist."""
+    response = await client.get("/api/auth/setup-status")
+    assert response.status_code == 200
+    assert response.json() == {"setup_required": True}
+
+
+@pytest.mark.asyncio
+async def test_setup_status_not_required_when_users_exist(client: AsyncClient, test_user):
+    """setup-status returns setup_required: false when users exist."""
+    response = await client.get("/api/auth/setup-status")
+    assert response.status_code == 200
+    assert response.json() == {"setup_required": False}
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_admin_and_returns_token(
+    client: AsyncClient, db: asyncpg.Connection
+):
+    """setup creates the first user as admin and returns access token + user."""
+    response = await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "admin_setup",
+            "email": "admin@example.com",
+            "password": "password123",
+            "display_name": "Admin User",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+    assert data["user"]["username"] == "admin_setup"
+    assert data["user"]["email"] == "admin@example.com"
+    assert data["user"]["display_name"] == "Admin User"
+    assert data["user"]["is_admin"] is True
+
+    # Verify refresh cookie was set
+    assert "jamarr_refresh" in response.cookies
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_admin_in_database(
+    client: AsyncClient, db: asyncpg.Connection
+):
+    """setup correctly sets is_admin = TRUE in the database."""
+    await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "db_admin",
+            "email": "dbadmin@example.com",
+            "password": "password123",
+        },
+    )
+    user = await db.fetchrow('SELECT * FROM "user" WHERE username = $1', "db_admin")
+    assert user is not None
+    assert user["is_admin"] is True
+
+
+@pytest.mark.asyncio
+async def test_second_setup_returns_409(client: AsyncClient, db: asyncpg.Connection):
+    """A second setup request returns 409 Conflict."""
+    # First setup succeeds
+    first = await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "first_admin",
+            "email": "first@example.com",
+            "password": "password123",
+        },
+    )
+    assert first.status_code == 201
+
+    # Second setup must fail
+    second = await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "second_admin",
+            "email": "second@example.com",
+            "password": "password123",
+        },
+    )
+    assert second.status_code == 409
+    detail = second.json()
+    assert "already been completed" in detail["detail"]
+
+
+@pytest.mark.asyncio
+async def test_setup_rejects_short_password(
+    client: AsyncClient, db: asyncpg.Connection
+):
+    """setup rejects passwords shorter than 8 characters."""
+    response = await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "shortpw",
+            "email": "short@example.com",
+            "password": "abc",
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_refresh_session(
+    client: AsyncClient, db: asyncpg.Connection
+):
+    """setup creates a refresh session in the database."""
+    response = await client.post(
+        "/api/auth/setup",
+        json={
+            "username": "session_test",
+            "email": "session@example.com",
+            "password": "password123",
+        },
+    )
+    assert response.status_code == 201
+    user_id = response.json()["user"]["id"]
+
+    session_count = await db.fetchval(
+        "SELECT COUNT(*) FROM auth_refresh_session WHERE user_id = $1 AND revoked_at IS NULL",
+        user_id,
+    )
+    assert session_count == 1

--- a/tests/auth/test_migration_027.py
+++ b/tests/auth/test_migration_027.py
@@ -9,20 +9,20 @@ from migrations.apply_migrations import _split_statements
 
 
 @pytest.mark.asyncio
-async def test_migration_027_marks_only_chris_admin(db: asyncpg.Connection):
+async def test_migration_027_preserves_existing_admin_flags(db: asyncpg.Connection):
     migration = Path("migrations/027_user_admin_flag.sql")
     statements = _split_statements(migration.read_text())
 
     tx = db.transaction()
     await tx.start()
     try:
-        await db.execute('DELETE FROM "user" WHERE username IN ($1, $2)', "chris", "not_chris")
+        await db.execute('DELETE FROM "user" WHERE username IN ($1, $2)', "admin_user", "regular_user")
         await db.execute(
             """
             INSERT INTO "user" (username, email, password_hash, display_name, is_admin, created_at)
             VALUES
-                ('chris', 'chris@example.com', $1, 'Chris', FALSE, NOW()),
-                ('not_chris', 'not_chris@example.com', $1, 'Not Chris', TRUE, NOW())
+                ('admin_user', 'admin@example.com', $1, 'Admin', TRUE, NOW()),
+                ('regular_user', 'regular@example.com', $1, 'Regular', FALSE, NOW())
             """,
             hash_password("password123"),
         )
@@ -32,11 +32,11 @@ async def test_migration_027_marks_only_chris_admin(db: asyncpg.Connection):
 
         rows = await db.fetch(
             'SELECT username, is_admin FROM "user" WHERE username IN ($1, $2)',
-            "chris",
-            "not_chris",
+            "admin_user",
+            "regular_user",
         )
         flags = {row["username"]: row["is_admin"] for row in rows}
-        assert flags == {"chris": True, "not_chris": False}
+        assert flags == {"admin_user": True, "regular_user": False}
     finally:
         await tx.rollback()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,26 +117,29 @@ async def db() -> AsyncGenerator[asyncpg.Connection, None]:
             "client_session",
             "renderer_state",
             "playback_history",
-            "track",
-            "artist",
-            "album",
-            "missing_album",
-            "artwork",
-            "renderer",
-            "top_track",
-            "similar_artist",
-            "artist_genre",
-            "external_link",
-            "image_map",
-            "lastfm_scrobble",
-            "lastfm_scrobble_match",
-            "lastfm_skip_artist",
-            "track_artist",
-            "artist_album",
-            "favorite_artist",
-            "favorite_release",
+            'track',
+            'artist',
+            'album',
+            'missing_album',
+            'artwork',
+            'renderer',
+            'top_track',
+            'similar_artist',
+            'artist_genre',
+            'external_link',
+            'image_map',
+            'lastfm_scrobble',
+            'lastfm_scrobble_match',
+            'lastfm_skip_artist',
+            'track_artist',
+            'artist_album',
+            'favorite_artist',
+            'favorite_release',
         ]
-        truncate = [t for t in tables if t in existing]
+        # user is a reserved word, needs quoting
+        if 'user' in existing:
+            tables.append('"user"')
+        truncate = [t for t in tables if t in existing or (t == '"user"' and 'user' in existing)]
         if truncate:
             await conn.execute(
                 f"TRUNCATE TABLE {', '.join(truncate)} RESTART IDENTITY CASCADE;"

--- a/tests/test_security_config.py
+++ b/tests/test_security_config.py
@@ -32,10 +32,10 @@ def _security_test_app() -> FastAPI:
 
 
 def test_parse_csv_env_trims_empty_values(monkeypatch):
-    monkeypatch.setenv("ALLOWED_HOSTS", " jamarr.darious.co.uk, ,REDACTED_IP ")
+    monkeypatch.setenv("ALLOWED_HOSTS", " jamarr.example.com, ,REDACTED_IP ")
 
     assert parse_csv_env("ALLOWED_HOSTS") == [
-        "jamarr.darious.co.uk",
+        "jamarr.example.com",
         "REDACTED_IP",
     ]
 
@@ -150,7 +150,7 @@ asyncio.run(main())
 
 @pytest.mark.asyncio
 async def test_allowed_hosts_are_enforced_when_configured(monkeypatch):
-    monkeypatch.setenv("ALLOWED_HOSTS", "jamarr.darious.co.uk,REDACTED_IP")
+    monkeypatch.setenv("ALLOWED_HOSTS", "jamarr.example.com,REDACTED_IP")
     app = _security_test_app()
 
     async with AsyncClient(
@@ -167,7 +167,7 @@ async def test_allowed_hosts_are_enforced_when_configured(monkeypatch):
 async def test_cors_allows_only_configured_origins(monkeypatch):
     monkeypatch.setenv(
         "ALLOWED_ORIGINS",
-        "https://jamarr.darious.co.uk,http://REDACTED_IP:8111",
+        "https://jamarr.example.com,http://REDACTED_IP:8111",
     )
     app = _security_test_app()
 
@@ -177,7 +177,7 @@ async def test_cors_allows_only_configured_origins(monkeypatch):
         allowed = await client.options(
             "/whoami",
             headers={
-                "Origin": "https://jamarr.darious.co.uk",
+                "Origin": "https://jamarr.example.com",
                 "Access-Control-Request-Method": "GET",
             },
         )
@@ -192,7 +192,7 @@ async def test_cors_allows_only_configured_origins(monkeypatch):
     assert allowed.status_code == 200
     assert (
         allowed.headers["access-control-allow-origin"]
-        == "https://jamarr.darious.co.uk"
+        == "https://jamarr.example.com"
     )
     assert blocked.status_code == 400
     assert "access-control-allow-origin" not in blocked.headers

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -527,6 +527,37 @@ export async function login(data: { username: string; password: string }): Promi
     return await res.json();
 }
 
+export interface SetupStatus {
+    setup_required: boolean;
+}
+
+export interface SetupPayload {
+    username: string;
+    email: string;
+    password: string;
+    display_name?: string;
+}
+
+export async function checkSetupStatus(): Promise<SetupStatus> {
+    const res = await fetch('/api/auth/setup-status');
+    if (!res.ok) throw new Error('Failed to check setup status');
+    return await res.json();
+}
+
+export async function setupFirstUser(data: SetupPayload): Promise<LoginResponse> {
+    const res = await fetch('/api/auth/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(data)
+    });
+    if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail.detail || 'Setup failed');
+    }
+    return await res.json();
+}
+
 export async function logout(): Promise<void> {
     await fetchWithAuth('/api/auth/logout', {
         method: 'POST',

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { goto } from "$app/navigation";
-  import { login } from "$lib/api";
+  import { login, setupFirstUser, checkSetupStatus } from "$lib/api";
   import TabButton from "$lib/components/TabButton.svelte";
   import {
     currentUser,
@@ -13,14 +13,18 @@
 
   let username = "";
   let password = "";
+  let email = "";
+  let displayName = "";
   let error = "";
   let loading = false;
+  let setupMode = false;
+  let setupChecked = false;
   let user = null;
   let authReady = false;
   let unsubUser: (() => void) | undefined;
   let unsubAuth: (() => void) | undefined;
 
-  onMount(() => {
+  onMount(async () => {
     unsubUser = currentUser.subscribe((value) => {
       user = value;
       if (authReady && user) goto("/");
@@ -30,6 +34,14 @@
       if (authReady && user) goto("/");
     });
     hydrateUser().catch(() => {});
+
+    try {
+      const status = await checkSetupStatus();
+      setupMode = status.setup_required;
+    } catch {
+      // If setup-status fails, assume it's already configured — show login
+    }
+    setupChecked = true;
   });
 
   onDestroy(() => {
@@ -42,20 +54,33 @@
     error = "";
     try {
       const response = await login({ username, password });
-      
-      // Store access token in memory
       setAccessToken(response.access_token);
-      
-      // Update user store
       setUser(response.user);
-      
-      // Setup automatic token refresh
       setupTokenRefresh();
-      
-      // Redirect to home
       goto("/");
     } catch (e: any) {
       error = e?.message || "Login failed.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleSetup() {
+    loading = true;
+    error = "";
+    try {
+      const response = await setupFirstUser({
+        username,
+        email,
+        password,
+        display_name: displayName || undefined,
+      });
+      setAccessToken(response.access_token);
+      setUser(response.user);
+      setupTokenRefresh();
+      goto("/");
+    } catch (e: any) {
+      error = e?.message || "Setup failed.";
     } finally {
       loading = false;
     }
@@ -76,65 +101,155 @@
       />
     </div>
 
-    <div
-      class="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur"
-    >
-      <div class="mb-6 text-center">
-        <p class="text-sm text-white/60">Welcome back to</p>
-        <h1 class="text-2xl font-semibold text-white">Jamarr</h1>
-        <p class="text-sm text-white/60">
-          Sign in with your username to continue.
-        </p>
+    {#if !setupChecked}
+      <div class="text-white/60">Loading...</div>
+    {:else if setupMode}
+      <div
+        class="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+      >
+        <div class="mb-6 text-center">
+          <p class="text-sm text-white/60">Welcome to</p>
+          <h1 class="text-2xl font-semibold text-white">Jamarr</h1>
+          <p class="text-sm text-white/60">
+            Create your admin account to get started.
+          </p>
+        </div>
+
+        {#if error}
+          <div
+            class="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-100"
+          >
+            {error}
+          </div>
+        {/if}
+
+        <form class="space-y-4" on:submit|preventDefault={handleSetup}>
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="setup-username"
+              >Username</label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              id="setup-username"
+              name="username"
+              autocomplete="username"
+              bind:value={username}
+              required
+            />
+          </div>
+
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="setup-email"
+              >Email</label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              type="email"
+              id="setup-email"
+              name="email"
+              autocomplete="email"
+              bind:value={email}
+              required
+            />
+          </div>
+
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="setup-display-name"
+              >Display name <span class="text-white/40">(optional)</span></label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              id="setup-display-name"
+              name="display_name"
+              bind:value={displayName}
+            />
+          </div>
+
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="setup-password"
+              >Password</label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              type="password"
+              id="setup-password"
+              name="password"
+              autocomplete="new-password"
+              bind:value={password}
+              required
+              minlength="8"
+            />
+          </div>
+
+          <TabButton
+            type="submit"
+            disabled={loading}
+            className="w-full justify-center"
+          >
+            {loading ? "Setting up..." : "Create Account"}
+          </TabButton>
+        </form>
       </div>
-
-      {#if error}
-        <div
-          class="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-100"
-        >
-          {error}
+    {:else}
+      <div
+        class="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+      >
+        <div class="mb-6 text-center">
+          <p class="text-sm text-white/60">Welcome back to</p>
+          <h1 class="text-2xl font-semibold text-white">Jamarr</h1>
+          <p class="text-sm text-white/60">
+            Sign in with your username to continue.
+          </p>
         </div>
-      {/if}
 
-      <form class="space-y-4" on:submit|preventDefault={handleLogin}>
-        <div class="space-y-2">
-          <label class="block text-sm text-white/70" for="username-input"
-            >Username</label
+        {#if error}
+          <div
+            class="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-100"
           >
-          <input
-            class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
-            id="username-input"
-            name="username"
-            autocomplete="username"
-            bind:value={username}
-            required
-          />
-        </div>
+            {error}
+          </div>
+        {/if}
 
-        <div class="space-y-2">
-          <label class="block text-sm text-white/70" for="password-input"
-            >Password</label
+        <form class="space-y-4" on:submit|preventDefault={handleLogin}>
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="login-username"
+              >Username</label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              id="login-username"
+              name="username"
+              autocomplete="username"
+              bind:value={username}
+              required
+            />
+          </div>
+
+          <div class="space-y-2">
+            <label class="block text-sm text-white/70" for="login-password"
+              >Password</label
+            >
+            <input
+              class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
+              type="password"
+              id="login-password"
+              name="password"
+              autocomplete="current-password"
+              bind:value={password}
+              required
+              minlength="8"
+            />
+          </div>
+
+          <TabButton
+            type="submit"
+            disabled={loading}
+            className="w-full justify-center"
           >
-          <input
-            class="input input-bordered w-full bg-white/5 text-white placeholder:text-white/40"
-            type="password"
-            id="password-input"
-            name="password"
-            autocomplete="current-password"
-            bind:value={password}
-            required
-            minlength="8"
-          />
-        </div>
-
-        <TabButton
-          type="submit"
-          disabled={loading}
-          className="w-full justify-center"
-        >
-          {loading ? "Signing in..." : "Sign In"}
-        </TabButton>
-      </form>
-
-    </div>
+            {loading ? "Signing in..." : "Sign In"}
+          </TabButton>
+        </form>
+      </div>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Removes the hardcoded `chris` admin user from `init_db()` and migration 027
- Adds `GET /api/auth/setup-status` and `POST /api/auth/setup` — race-safe first-admin creation via `pg_advisory_xact_lock`
- Login page shows setup form when the user table is empty, standard login otherwise
- Sanitises remaining PII: usernames, passwords, personal domain replaced with placeholders in scripts, tests, docs, and Android build config

## Test plan
- [x] 7 new tests for setup-status/setup endpoints (all pass)
- [x] Migration 027 test rewritten and passing
- [x] Full auth suite: 65 passed, 1 skipped (rate-limit test, dev-only)
- [x] Grep sweep confirms no remaining `chris`, `darious1472`, `sld23mxg`, or `jamarr.darious.co.uk` in tracked files