### PR TITLE
Tablet/landscape layouts for artist, album, now playing

### DIFF
--- a/android/app/src/main/java/com/jamarr/android/ui/components/Responsive.kt
+++ b/android/app/src/main/java/com/jamarr/android/ui/components/Responsive.kt
@@ -1,0 +1,10 @@
+package com.jamarr.android.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+
+@Composable
+fun isWide(): Boolean {
+    val cfg = LocalConfiguration.current
+    return cfg.smallestScreenWidthDp >= 600 || cfg.screenWidthDp >= 720
+}

--- a/android/app/src/main/java/com/jamarr/android/ui/screens/AlbumDetailScreen.kt
+++ b/android/app/src/main/java/com/jamarr/android/ui/screens/AlbumDetailScreen.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -14,6 +17,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +47,7 @@ import com.jamarr.android.ui.components.PlayShuffleActions
 import com.jamarr.android.ui.components.TrackRow
 import com.jamarr.android.ui.components.formatDuration
 import com.jamarr.android.ui.components.formatTotalDuration
+import com.jamarr.android.ui.components.isWide
 import com.jamarr.android.ui.components.seedColor
 import com.jamarr.android.ui.state.LocalJamarrContext
 import com.jamarr.android.ui.theme.JamarrColors
@@ -103,16 +109,35 @@ fun AlbumDetailScreen(
     val artworkUrl = ctx.artworkUrl(detail.value?.artSha1 ?: fallbackArtSha1, 800)
     val currentMediaId = ctx.playbackController.currentMediaId?.toLongOrNull()
 
+    val resolvedAlbumMbid = detail.value?.albumMbid ?: albumMbid
+    val onPlay: () -> Unit = {
+        if (tracks.value.isNotEmpty()) onPlayTracks(tracks.value, 0)
+    }
+    val onShuffle: () -> Unit = {
+        if (tracks.value.isNotEmpty()) onPlayTracks(tracks.value.shuffled(), 0)
+    }
+    val onToggleFavorite: () -> Unit = {
+        val mbid = resolvedAlbumMbid
+        if (!mbid.isNullOrBlank()) {
+            val desired = !isFavorite.value
+            isFavorite.value = desired
+            scope.launch {
+                runCatching {
+                    ctx.apiClient.setAlbumFavorite(
+                        serverUrl = ctx.serverUrl,
+                        accessToken = ctx.accessToken,
+                        albumMbid = mbid,
+                        favorite = desired,
+                    )
+                }.onFailure { isFavorite.value = !desired }
+            }
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize().background(JamarrColors.Bg)) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-                bottom = contentPadding.calculateBottomPadding() + 16.dp,
-            ),
-        ) {
-            item {
-                val resolvedAlbumMbid = detail.value?.albumMbid ?: albumMbid
-                AlbumHero(
+        if (isWide()) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                AlbumLeftPane(
                     title = title,
                     artist = artist,
                     year = year,
@@ -124,64 +149,198 @@ fun AlbumDetailScreen(
                     onArtistClick = onArtistClick,
                     canFavorite = !resolvedAlbumMbid.isNullOrBlank(),
                     isFavorite = isFavorite.value,
-                    onToggleFavorite = {
-                        val mbid = resolvedAlbumMbid ?: return@AlbumHero
-                        val desired = !isFavorite.value
-                        isFavorite.value = desired
-                        scope.launch {
-                            runCatching {
-                                ctx.apiClient.setAlbumFavorite(
-                                    serverUrl = ctx.serverUrl,
-                                    accessToken = ctx.accessToken,
-                                    albumMbid = mbid,
-                                    favorite = desired,
-                                )
-                            }.onFailure { isFavorite.value = !desired }
+                    onToggleFavorite = onToggleFavorite,
+                    onPlay = onPlay,
+                    onShuffle = onShuffle,
+                    modifier = Modifier
+                        .width(500.dp)
+                        .fillMaxHeight()
+                        .verticalScroll(rememberScrollState())
+                        .padding(JamarrDims.ScreenPadding),
+                )
+                LazyColumn(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    contentPadding = PaddingValues(
+                        top = 16.dp,
+                        bottom = contentPadding.calculateBottomPadding() + 16.dp,
+                    ),
+                ) {
+                    if (errorState.value != null && tracks.value.isEmpty()) {
+                        item {
+                            Text(
+                                text = errorState.value.orEmpty(),
+                                style = JamarrType.Body,
+                                color = JamarrColors.Muted,
+                                modifier = Modifier.padding(horizontal = JamarrDims.ScreenPadding),
+                            )
                         }
-                    },
-                )
-            }
-            item {
-                Column(modifier = Modifier.padding(horizontal = JamarrDims.ScreenPadding, vertical = 16.dp)) {
-                    PlayShuffleActions(
-                        onPlay = {
-                            if (tracks.value.isNotEmpty()) {
-                                onPlayTracks(tracks.value, 0)
-                            }
-                        },
-                        onShuffle = {
-                            if (tracks.value.isNotEmpty()) {
-                                val shuffled = tracks.value.shuffled()
-                                onPlayTracks(shuffled, 0)
-                            }
-                        },
-                    )
+                    }
+                    items(tracks.value, key = { it.id }) { track ->
+                        TrackRow(
+                            number = tracks.value.indexOf(track) + 1,
+                            title = track.title,
+                            subtitle = track.artist,
+                            duration = formatDuration(track.durationSeconds),
+                            active = currentMediaId == track.id,
+                            onClick = {
+                                val start = tracks.value.indexOf(track).coerceAtLeast(0)
+                                onPlayTracks(tracks.value, start)
+                            },
+                        )
+                    }
                 }
             }
-            if (errorState.value != null && tracks.value.isEmpty()) {
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    bottom = contentPadding.calculateBottomPadding() + 16.dp,
+                ),
+            ) {
                 item {
-                    Text(
-                        text = errorState.value.orEmpty(),
-                        style = JamarrType.Body,
-                        color = JamarrColors.Muted,
-                        modifier = Modifier.padding(horizontal = JamarrDims.ScreenPadding),
+                    AlbumHero(
+                        title = title,
+                        artist = artist,
+                        year = year,
+                        trackCount = trackCount,
+                        totalDuration = totalDuration,
+                        artworkUrl = artworkUrl,
+                        seed = title + artist,
+                        onBack = onBack,
+                        onArtistClick = onArtistClick,
+                        canFavorite = !resolvedAlbumMbid.isNullOrBlank(),
+                        isFavorite = isFavorite.value,
+                        onToggleFavorite = onToggleFavorite,
                     )
                 }
-            }
-            items(tracks.value, key = { it.id }) { track ->
-                TrackRow(
-                    number = tracks.value.indexOf(track) + 1,
-                    title = track.title,
-                    subtitle = track.artist,
-                    duration = formatDuration(track.durationSeconds),
-                    active = currentMediaId == track.id,
-                    onClick = {
-                        val start = tracks.value.indexOf(track).coerceAtLeast(0)
-                        onPlayTracks(tracks.value, start)
-                    },
-                )
+                item {
+                    Column(modifier = Modifier.padding(horizontal = JamarrDims.ScreenPadding, vertical = 16.dp)) {
+                        PlayShuffleActions(onPlay = onPlay, onShuffle = onShuffle)
+                    }
+                }
+                if (errorState.value != null && tracks.value.isEmpty()) {
+                    item {
+                        Text(
+                            text = errorState.value.orEmpty(),
+                            style = JamarrType.Body,
+                            color = JamarrColors.Muted,
+                            modifier = Modifier.padding(horizontal = JamarrDims.ScreenPadding),
+                        )
+                    }
+                }
+                items(tracks.value, key = { it.id }) { track ->
+                    TrackRow(
+                        number = tracks.value.indexOf(track) + 1,
+                        title = track.title,
+                        subtitle = track.artist,
+                        duration = formatDuration(track.durationSeconds),
+                        active = currentMediaId == track.id,
+                        onClick = {
+                            val start = tracks.value.indexOf(track).coerceAtLeast(0)
+                            onPlayTracks(tracks.value, start)
+                        },
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun AlbumLeftPane(
+    title: String,
+    artist: String,
+    year: String?,
+    trackCount: Int?,
+    totalDuration: Double?,
+    artworkUrl: String?,
+    seed: String,
+    onBack: () -> Unit,
+    onArtistClick: () -> Unit,
+    canFavorite: Boolean,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit,
+    onPlay: () -> Unit,
+    onShuffle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth().statusBarsPadding(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(34.dp)
+                    .clip(CircleShape)
+                    .background(Color(0x66000000))
+                    .clickable(onClick = onBack),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(text = "←", color = Color.White, style = JamarrType.CardTitle)
+            }
+            Spacer(Modifier.weight(1f))
+            if (canFavorite) {
+                Box(
+                    modifier = Modifier
+                        .size(34.dp)
+                        .clip(CircleShape)
+                        .background(Color(0x66000000))
+                        .clickable(onClick = onToggleFavorite),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    HeartIcon(
+                        tint = if (isFavorite) JamarrColors.Primary else Color.White,
+                        filled = isFavorite,
+                        size = 18.dp,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(JamarrShapes.AlbumArt),
+        ) {
+            AlbumArt(
+                title = title,
+                seedName = seed,
+                artworkUrl = artworkUrl,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        Spacer(Modifier.height(20.dp))
+        Text(
+            text = title,
+            style = JamarrType.AlbumHeroTitle,
+            color = JamarrColors.Text,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = artist,
+            style = JamarrType.ArtistLink,
+            color = JamarrColors.Primary,
+            modifier = Modifier.clickable(onClick = onArtistClick),
+        )
+        Spacer(Modifier.height(8.dp))
+        val metaParts = listOfNotNull(
+            year,
+            trackCount?.let { "$it track${if (it == 1) "" else "s"}" },
+            formatTotalDuration(totalDuration),
+        )
+        if (metaParts.isNotEmpty()) {
+            Text(
+                text = metaParts.joinToString(" · "),
+                style = JamarrType.Caption,
+                color = JamarrColors.Muted,
+            )
+        }
+        Spacer(Modifier.height(20.dp))
+        PlayShuffleActions(onPlay = onPlay, onShuffle = onShuffle)
     }
 }
 

--- a/android/app/src/main/java/com/jamarr/android/ui/screens/ArtistDetailScreen.kt
+++ b/android/app/src/main/java/com/jamarr/android/ui/screens/ArtistDetailScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -50,6 +52,7 @@ import com.jamarr.android.ui.components.HeartIcon
 import com.jamarr.android.ui.components.PlayIcon
 import com.jamarr.android.ui.components.TrackRow
 import com.jamarr.android.ui.components.formatDuration
+import com.jamarr.android.ui.components.isWide
 import com.jamarr.android.ui.components.seedColor
 import com.jamarr.android.ui.state.LocalJamarrContext
 import com.jamarr.android.ui.theme.JamarrColors
@@ -142,6 +145,8 @@ fun ArtistDetailScreen(
                 bottom = contentPadding.calculateBottomPadding() + 16.dp,
             ),
         ) {
+            val bio = detail.value?.bio
+            val links = detail.value.collectLinks()
             item {
                 val artImageUrl = ctx.artworkUrl(detail.value?.artSha1 ?: initialArtSha1, 800)
                     ?: detail.value?.imageUrl
@@ -171,14 +176,13 @@ fun ArtistDetailScreen(
                 )
             }
 
-            val bio = detail.value?.bio
             if (!bio.isNullOrBlank()) {
                 item {
                     Text(
                         text = bio,
                         style = JamarrType.Body,
                         color = JamarrColors.Muted,
-                        maxLines = 4,
+                        maxLines = 6,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.padding(
                             horizontal = JamarrDims.ScreenPadding,
@@ -188,7 +192,6 @@ fun ArtistDetailScreen(
                 }
             }
 
-            val links = detail.value.collectLinks()
             if (links.isNotEmpty()) {
                 item {
                     LinksRow(links)
@@ -329,11 +332,19 @@ private fun ArtistHero(
     isFavorite: Boolean,
     onToggleFavorite: () -> Unit,
 ) {
+    // Mirror web pattern: full-bleed image hero, scaled tall on wide screens.
+    // Web uses h-[42vh sm:48vh md:60vh] with min-h-[500px] on md+.
+    val cfg = androidx.compose.ui.platform.LocalConfiguration.current
+    val heroHeight = if (isWide()) {
+        (cfg.screenHeightDp * 0.6f).dp.coerceAtLeast(420.dp)
+    } else {
+        (cfg.screenHeightDp * 0.42f).dp.coerceAtLeast(300.dp)
+    }
     val top = seedColor(name)
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(300.dp)
+            .height(heroHeight)
             .background(Brush.verticalGradient(listOf(top, JamarrColors.Bg))),
     ) {
         if (!artImageUrl.isNullOrBlank()) {
@@ -341,13 +352,14 @@ private fun ArtistHero(
                 model = artImageUrl,
                 contentDescription = name,
                 contentScale = ContentScale.Crop,
+                alignment = Alignment.TopCenter,
                 modifier = Modifier.fillMaxSize(),
             )
         }
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(160.dp)
+                .height(heroHeight * 0.55f)
                 .align(Alignment.BottomCenter)
                 .background(
                     Brush.verticalGradient(
@@ -391,8 +403,8 @@ private fun ArtistHero(
                 .fillMaxWidth()
                 .align(Alignment.BottomStart)
                 .padding(
-                    horizontal = JamarrDims.ScreenPadding,
-                    vertical = 16.dp,
+                    horizontal = if (isWide()) 48.dp else JamarrDims.ScreenPadding,
+                    vertical = if (isWide()) 32.dp else 16.dp,
                 ),
         ) {
             Text(

--- a/android/app/src/main/java/com/jamarr/android/ui/screens/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/jamarr/android/ui/screens/NowPlayingScreen.kt
@@ -16,14 +16,17 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -58,6 +61,7 @@ import com.jamarr.android.ui.components.RepeatOneIcon
 import com.jamarr.android.ui.components.ShuffleIcon
 import com.jamarr.android.ui.components.SkipNextIcon
 import com.jamarr.android.ui.components.SkipPreviousIcon
+import com.jamarr.android.ui.components.isWide
 import com.jamarr.android.ui.components.seedColor
 import com.jamarr.android.ui.theme.JamarrColors
 import com.jamarr.android.ui.theme.JamarrDims
@@ -123,43 +127,87 @@ fun NowPlayingSheet(
                     onToggleQueue = { showQueue = !showQueue },
                 )
 
-                if (showQueue) {
-                    QueueView(
-                        queue = queue,
-                        currentTrackId = track.id,
-                        onItemClick = onQueueItemClick,
-                        modifier = Modifier.weight(1f),
-                    )
+                if (isWide() && !showQueue) {
+                    Row(
+                        modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 48.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(48.dp, Alignment.CenterHorizontally),
+                    ) {
+                        ArtworkPane(
+                            track = track,
+                            artworkUrl = artworkUrl,
+                            isPlaying = isPlaying,
+                            modifier = Modifier.fillMaxHeight().aspectRatio(1f),
+                        )
+                        Column(
+                            modifier = Modifier
+                                .widthIn(max = 672.dp)
+                                .weight(1f)
+                                .fillMaxHeight(),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            TrackInfo(track = track, onArtistClick = onArtistClick)
+                            Spacer(Modifier.height(28.dp))
+                            ScrubBar(
+                                progressMs = progressMs,
+                                durationMs = durationMs,
+                                onSeek = onSeek,
+                                horizontalPadding = 0.dp,
+                            )
+                            TransportControls(
+                                isPlaying = isPlaying,
+                                shuffleEnabled = shuffleEnabled,
+                                repeatMode = repeatMode,
+                                onToggle = onToggle,
+                                onPrevious = onPrevious,
+                                onNext = onNext,
+                                onShuffle = onShuffle,
+                                onRepeat = onRepeat,
+                                horizontalPadding = 0.dp,
+                            )
+                        }
+                    }
+                    Spacer(Modifier.height(24.dp))
                 } else {
-                    ArtworkView(
-                        track = track,
-                        artworkUrl = artworkUrl,
-                        isPlaying = isPlaying,
-                        onArtistClick = onArtistClick,
-                        modifier = Modifier.weight(1f),
+                    if (showQueue) {
+                        QueueView(
+                            queue = queue,
+                            currentTrackId = track.id,
+                            onItemClick = onQueueItemClick,
+                            modifier = Modifier.weight(1f),
+                        )
+                    } else {
+                        ArtworkView(
+                            track = track,
+                            artworkUrl = artworkUrl,
+                            isPlaying = isPlaying,
+                            onArtistClick = onArtistClick,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+
+                    // Progress bar
+                    ScrubBar(
+                        progressMs = progressMs,
+                        durationMs = durationMs,
+                        onSeek = onSeek,
                     )
+
+                    // Transport controls
+                    TransportControls(
+                        isPlaying = isPlaying,
+                        shuffleEnabled = shuffleEnabled,
+                        repeatMode = repeatMode,
+                        onToggle = onToggle,
+                        onPrevious = onPrevious,
+                        onNext = onNext,
+                        onShuffle = onShuffle,
+                        onRepeat = onRepeat,
+                    )
+
+                    Spacer(Modifier.height(24.dp))
                 }
-
-                // Progress bar
-                ScrubBar(
-                    progressMs = progressMs,
-                    durationMs = durationMs,
-                    onSeek = onSeek,
-                )
-
-                // Transport controls
-                TransportControls(
-                    isPlaying = isPlaying,
-                    shuffleEnabled = shuffleEnabled,
-                    repeatMode = repeatMode,
-                    onToggle = onToggle,
-                    onPrevious = onPrevious,
-                    onNext = onNext,
-                    onShuffle = onShuffle,
-                    onRepeat = onRepeat,
-                )
-
-                Spacer(Modifier.height(24.dp))
             }
         }
     }
@@ -229,9 +277,10 @@ private fun ArtworkView(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Album art
+        // Album art (capped so controls always have room)
         Box(
             modifier = Modifier
+                .widthIn(max = 360.dp)
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .scale(artScale)
@@ -292,10 +341,79 @@ private fun ArtworkView(
 }
 
 @Composable
+private fun ArtworkPane(
+    track: SearchTrack,
+    artworkUrl: String?,
+    isPlaying: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val artScale by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0.88f,
+        animationSpec = tween(400),
+        label = "art-scale-wide",
+    )
+    Box(
+        modifier = modifier
+            .scale(artScale)
+            .clip(JamarrShapes.AlbumArtLarge)
+            .background(JamarrColors.Card),
+    ) {
+        AlbumArt(
+            title = track.title,
+            seedName = track.album ?: track.title,
+            artworkUrl = artworkUrl,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun TrackInfo(
+    track: SearchTrack,
+    onArtistClick: (String) -> Unit,
+) {
+    Text(
+        text = track.title,
+        style = JamarrType.AlbumHeroTitle,
+        color = JamarrColors.Text,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(4.dp))
+    val artist = track.artist
+    if (!artist.isNullOrBlank()) {
+        Text(
+            text = artist,
+            style = JamarrType.ArtistLink,
+            color = JamarrColors.Primary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onArtistClick(artist) },
+        )
+    }
+    val album = track.album
+    if (!album.isNullOrBlank()) {
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = album,
+            style = JamarrType.Caption,
+            color = JamarrColors.Muted,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
 private fun ScrubBar(
     progressMs: Long,
     durationMs: Long,
     onSeek: (Long) -> Unit,
+    horizontalPadding: androidx.compose.ui.unit.Dp = 32.dp,
 ) {
     val fraction = if (durationMs > 0) {
         (progressMs.toFloat() / durationMs).coerceIn(0f, 1f)
@@ -308,7 +426,7 @@ private fun ScrubBar(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = horizontalPadding),
     ) {
         // Scrub track
         Box(
@@ -405,11 +523,12 @@ private fun TransportControls(
     onNext: () -> Unit,
     onShuffle: () -> Unit,
     onRepeat: () -> Unit,
+    horizontalPadding: androidx.compose.ui.unit.Dp = 32.dp,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp, vertical = 16.dp),
+            .padding(horizontal = horizontalPadding, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
     ) {


### PR DESCRIPTION
Wide-screen layouts (sw>=600dp or width>=720dp) for artist, album, now playing. Mirrors web layout patterns. Phone portrait unchanged.

- Artist: taller full-bleed hero (60% screen height) with top-aligned crop. Matches web `h-[60vh]`.
- Album: fixed 500dp left pane (artwork + meta + actions) + flex tracks. Matches web `grid-cols-[500px,1fr]`.
- Now Playing: square artwork at full row height, right column capped 672dp. Matches web 80vh artwork + `max-w-2xl`.
- New `isWide()` helper in `ui/components/Responsive.kt`.