### PR TITLE
feat(renderer): add Chromecast backend with protocol-neutral orchestration

### DIFF
--- a/app/api/player.py
+++ b/app/api/player.py
@@ -7,7 +7,6 @@ import time
 from typing import Optional
 import asyncpg
 from app.db import get_db
-from app.upnp import UPnPManager
 from app.api.deps import (
     get_current_admin_user_jwt,
     get_current_user_jwt,
@@ -26,12 +25,8 @@ from app.models.player import (
 from app.services.player.globals import (
     playback_monitors,
     monitor_start_times,
-    last_track_start_time,
 )
 from app.services.player.state import (
-    track_path_exists,
-    enrich_track_metadata,
-    get_active_renderer,
     get_renderer_state_db,
     update_renderer_state_db,
 )
@@ -41,16 +36,14 @@ from app.services.player.history import (
     update_now_playing_lastfm,
 )
 from app.services.player.monitor import (
-    monitor_upnp_playback,
     start_monitor_task,
-    _mark_monitor_starting,
-    _clear_monitor_starting,
     _is_monitor_starting,
 )
+from app.services.renderer import get_renderer_orchestrator
 
 router = APIRouter(dependencies=[Depends(get_current_user_jwt)])
 logger = logging.getLogger(__name__)
-upnp = UPnPManager.get_instance()
+renderer_orchestrator = get_renderer_orchestrator()
 
 
 async def get_client_id(x_jamarr_client_id: Optional[str] = Header(None)) -> str:
@@ -68,7 +61,7 @@ async def get_client_ip_endpoint(request: Request):
 @router.get("/api/player/state", response_model=PlayerState)
 async def get_player_state(client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
+        renderer_id, udn = await renderer_orchestrator.get_active(db, client_id)
         state = await get_renderer_state_db(db, udn)
 
         # If UPnP, sync live state
@@ -172,6 +165,8 @@ async def get_player_state(client_id: str = Depends(get_client_id)):
             "position_seconds": state["position_seconds"],
             "is_playing": state["is_playing"],
             "renderer": udn,
+            "renderer_id": renderer_id,
+            "renderer_kind": renderer_id.split(":", 1)[0] if ":" in renderer_id else "upnp",
             "transport_state": state.get("transport_state", "STOPPED"),
             "volume": state.get("volume"),
         }
@@ -195,8 +190,6 @@ async def set_queue(
     user: asyncpg.Record = Depends(get_current_user_jwt),
 ):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-        state = await get_renderer_state_db(db, udn)
         user_id = user["id"]
 
         enriched_queue = []
@@ -205,68 +198,24 @@ async def set_queue(
             if user_id is not None:
                 track_dict["user_id"] = user_id
             enriched_queue.append(track_dict)
-
-        state["queue"] = enriched_queue
-        state["current_index"] = max(
-            0, min(update.start_index, len(enriched_queue) - 1 if enriched_queue else 0)
-        )
-        state["position_seconds"] = 0
-        state["is_playing"] = True
-        state["transport_state"] = "PLAYING"
-
-        await update_renderer_state_db(db, udn, state)
-        reset_history_tracker(udn if not udn.startswith("local") else client_id)
         
         # Trigger Now Playing update for Last.fm
-        if enriched_queue and state["current_index"] >= 0:
-            current_track = enriched_queue[state["current_index"]]
+        if enriched_queue:
+            current_index = max(
+                0, min(update.start_index, len(enriched_queue) - 1)
+            )
+            current_track = enriched_queue[current_index]
             asyncio.create_task(
                 update_now_playing_lastfm(user_id, current_track["id"])
             )
-
-        # For UPnP, immediately play the selected track and restart monitor
-        if not udn.startswith("local:") and state["queue"]:
-            # pick first playable track from start_index onward
-            playable_idx = None
-            for idx in range(state["current_index"], len(state["queue"])):
-                candidate = await enrich_track_metadata(state["queue"][idx], db)
-                if track_path_exists(candidate):
-                    state["queue"][idx] = candidate
-                    playable_idx = idx
-                    break
-            if playable_idx is None:
-                raise HTTPException(
-                    status_code=404,
-                    detail="No playable tracks found on disk for this queue.",
-                )
-            state["current_index"] = playable_idx
-            await update_renderer_state_db(db, udn, state)
-
-            # Cancel existing monitor
-            if udn in playback_monitors:
-                playback_monitors[udn].cancel()
-                try:
-                    await asyncio.wait([playback_monitors[udn]], timeout=1)
-                except Exception:
-                    pass
-
-            # Start playback in background to avoid blocking HTTP response
-            async def start_playback():
-                try:
-                    await upnp.set_renderer(udn)
-                    env_port = os.environ.get("HOST_PORT")
-                    port = env_port if env_port else (request.url.port or 8111)
-                    upnp.base_url = f"http://{upnp.local_ip}:{port}"
-                    track = state["queue"][state["current_index"]]
-                    await upnp.play_track(track["id"], track.get("path"), track)
-                    start_monitor_task(udn)
-                    last_track_start_time[udn] = time.time()
-                finally:
-                    _clear_monitor_starting(udn)
-
-            # Start playback in background
-            _mark_monitor_starting(udn)
-            asyncio.create_task(start_playback())
+        await renderer_orchestrator.set_queue(
+            db,
+            client_id,
+            enriched_queue,
+            update.start_index,
+            user_id,
+            request,
+        )
 
     return {"status": "ok"}
 
@@ -282,7 +231,7 @@ async def append_queue(
     user: asyncpg.Record = Depends(get_current_user_jwt),
 ):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
+        _, udn = await renderer_orchestrator.get_active(db, client_id)
         state = await get_renderer_state_db(db, udn)
         user_id = user["id"]
 
@@ -310,7 +259,7 @@ async def reorder_queue(
     Expects the same queue items in a new order.
     """
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
+        _, udn = await renderer_orchestrator.get_active(db, client_id)
         state = await get_renderer_state_db(db, udn)
         existing_queue = state.get("queue") or []
 
@@ -392,31 +341,7 @@ async def clear_queue(client_id: str = Depends(get_client_id)):
     Empty the active renderer queue and stop playback.
     """
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-        state = await get_renderer_state_db(db, udn)
-
-        state["queue"] = []
-        state["current_index"] = -1
-        state["position_seconds"] = 0
-        state["is_playing"] = False
-        state["transport_state"] = "STOPPED"
-        await update_renderer_state_db(db, udn, state)
-        reset_history_tracker(client_id if udn.startswith("local") else udn)
-
-        if not udn.startswith("local:"):
-            try:
-                await upnp.set_renderer(udn)
-                await upnp.pause()
-            except Exception as e:
-                logger.warning(f"[Player] Failed to pause renderer {udn} on clear: {e}")
-
-            if udn in playback_monitors:
-                playback_monitors[udn].cancel()
-                try:
-                    await asyncio.wait([playback_monitors[udn]], timeout=1)
-                except Exception:
-                    pass
-                del playback_monitors[udn]
+        state, udn = await renderer_orchestrator.stop_or_clear(db, client_id)
 
         return {
             "status": "ok",
@@ -438,54 +363,7 @@ async def clear_queue(client_id: str = Depends(get_client_id)):
 )
 async def set_index(update: IndexUpdate, client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-        state = await get_renderer_state_db(db, udn)
-
-        state["current_index"] = update.index
-        state["position_seconds"] = 0
-        state["is_playing"] = True  # Assume play on skip
-        state["transport_state"] = "PLAYING"
-
-        await update_renderer_state_db(db, udn, state)
-        reset_history_tracker(client_id if udn.startswith("local") else udn)
-
-        if not udn.startswith("local:"):
-            queue = state.get("queue") or []
-            if queue and 0 <= state["current_index"] < len(queue):
-                # find next playable track from requested index forward
-                playable_idx = None
-                for idx in range(state["current_index"], len(queue)):
-                    candidate = await enrich_track_metadata(queue[idx], db)
-                    if track_path_exists(candidate):
-                        state["queue"][idx] = candidate
-                        playable_idx = idx
-                        break
-                if playable_idx is None:
-                    raise HTTPException(
-                        status_code=404, detail="Selected track is missing on disk."
-                    )
-                state["current_index"] = playable_idx
-                await update_renderer_state_db(db, udn, state)
-
-                if udn in playback_monitors:
-                    playback_monitors[udn].cancel()
-                    try:
-                        await asyncio.wait([playback_monitors[udn]], timeout=1)
-                    except Exception:
-                        pass
-
-                await upnp.set_renderer(udn)
-                env_port = os.environ.get("HOST_PORT")
-                port = env_port if env_port else 8111
-                upnp.base_url = f"http://{upnp.local_ip}:{port}"
-                track = state["queue"][state["current_index"]]
-                _mark_monitor_starting(udn)
-                try:
-                    await upnp.play_track(track["id"], track.get("path"), track)
-                    start_monitor_task(udn)
-                    last_track_start_time[udn] = time.time()
-                finally:
-                    _clear_monitor_starting(udn)
+        state, udn = await renderer_orchestrator.skip_to_index(db, client_id, update.index)
     # Return the state so the client can sync immediately
     return {
         "status": "ok",
@@ -521,7 +399,7 @@ async def update_progress(
     user: asyncpg.Record = Depends(get_current_user_jwt),
 ):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
+        _, udn = await renderer_orchestrator.get_active(db, client_id)
         client_ip = get_client_ip(request)
         user_id = user["id"]
         if udn.startswith("local:"):
@@ -570,11 +448,13 @@ async def update_progress(
 
 @router.get("/api/scan-status", dependencies=[Depends(get_current_admin_user_jwt)])
 async def get_scan_status(client_id: str = Depends(get_client_id)):
+    upnp_backend = renderer_orchestrator.registry.backends.get("upnp")
+    manager = getattr(upnp_backend, "manager", None)
     return {
-        "is_scanning": upnp.is_scanning_subnet,
-        "message": upnp.scan_msg,
-        "progress": upnp.scan_progress,
-        "logs": upnp.debug_log[-20:],
+        "is_scanning": getattr(manager, "is_scanning_subnet", False),
+        "message": getattr(manager, "scan_msg", ""),
+        "progress": getattr(manager, "scan_progress", 0),
+        "logs": getattr(manager, "debug_log", [])[-20:],
     }
 
 
@@ -587,16 +467,18 @@ async def get_renderers(
     if refresh:
         require_admin_user(user)
     
+    async for db in get_db():
+        renderers = await renderer_orchestrator.list_renderers(
+            db,
+            client_id,
+            refresh=refresh,
+        )
     if refresh:
-        await upnp.discover()
-        asyncio.create_task(upnp.scan_subnet())
-    renderers = await upnp.get_renderers()
-    local_device = {
-        "udn": f"local:{client_id}",
-        "name": "This Device (Web Browser)",
-        "type": "local",
-    }
-    return [local_device, *renderers]
+        upnp_backend = renderer_orchestrator.registry.backends.get("upnp")
+        manager = getattr(upnp_backend, "manager", None)
+        if manager:
+            asyncio.create_task(manager.scan_subnet())
+    return renderers
 
 
 @router.post(
@@ -604,23 +486,13 @@ async def get_renderers(
     dependencies=[Depends(get_current_admin_user_jwt)],
 )
 async def set_renderer(data: dict, client_id: str = Depends(get_client_id)):
-    udn = data.get("udn")
-    if not udn:
-        raise HTTPException(status_code=400, detail="Missing udn")
+    requested = data.get("renderer_id") or data.get("udn")
+    if not requested:
+        raise HTTPException(status_code=400, detail="Missing renderer_id")
 
     async for db in get_db():
-        await db.execute(
-            """
-            INSERT INTO client_session (client_id, active_renderer_udn, last_seen_at)
-            VALUES ($1, $2, NOW())
-            ON CONFLICT(client_id) DO UPDATE SET
-                active_renderer_udn = excluded.active_renderer_udn,
-                last_seen_at = NOW()
-        """,
-            client_id,
-            udn,
-        )
-    return {"active": udn}
+        renderer_id, state_key = await renderer_orchestrator.set_active(db, client_id, requested)
+    return {"active": state_key, "renderer_id": renderer_id}
 
 
 @router.post(
@@ -638,9 +510,6 @@ async def play_track(
     if not track_id:
         raise HTTPException(status_code=400, detail="Missing track_id")
 
-    udn = await get_active_renderer(db, client_id)
-
-    # Fetch track metadata
     # Fetch track metadata
     row = await db.fetchrow(
         """
@@ -695,120 +564,13 @@ async def play_track(
     track["mime"] = mime
     track["user_id"] = user_row["id"]
 
-    is_local = udn.startswith("local:") or udn == "local"
-
-    if not is_local:
-        # UPnP Playback
-        await upnp.set_renderer(udn)
-
-        env_port = os.environ.get("HOST_PORT")
-        port = env_port if env_port else (request.url.port or 8111)
-        upnp.base_url = f"http://{upnp.local_ip}:{port}"
-
-        state = await get_renderer_state_db(db, udn)
-
-        # Check if this track is already playing
-        current_track = None
-        if state.get("current_index") is not None and state.get("queue"):
-            queue = state["queue"]
-            if 0 <= state["current_index"] < len(queue):
-                current_track = queue[state["current_index"]]
-
-        if (
-            current_track
-            and current_track.get("id") == track["id"]
-            and state.get("is_playing")
-        ):
-            logger.info(f"play_track: Track {track_id} already playing. checking monitor...")
-            # Ensure monitor is running if it died
-            if udn not in playback_monitors or playback_monitors[udn].done():
-                logger.info(f"Restarting monitor for active track {track_id}")
-                start_monitor_task(udn)
-                last_track_start_time[udn] = time.time()
-            else:
-                 logger.info(f"play_track: Monitor already running for {udn}")
-            
-            logger.info(
-                f"Track {track_id} is already playing, ignoring duplicate play request"
-            )
-            return {"status": "already_playing", "renderer": udn}
-
-        # If paused, just resume
-        if (
-            current_track
-            and current_track.get("id") == track["id"]
-            and not state.get("is_playing")
-        ):
-            logger.info(f"Resuming track {track_id}")
-            await upnp.play()
-            state["is_playing"] = True
-            state["transport_state"] = "PLAYING"
-            await update_renderer_state_db(db, udn, state)
-            
-            # Start monitor
-            start_monitor_task(udn)
-            last_track_start_time[udn] = time.time()
-            
-            return {"status": "resumed", "renderer": udn}
-
-        # Different track or no track playing - start new playback
-        # Try to keep the existing queue if this track is in it; otherwise replace with single track
-        existing_queue = state.get("queue") or []
-        try:
-            current_index = next(
-                i for i, t in enumerate(existing_queue) if t.get("id") == track["id"]
-            )
-            existing_queue[current_index] = track
-        except StopIteration:
-            existing_queue = [track]
-            current_index = 0
-
-        state["queue"] = existing_queue
-        state["current_index"] = current_index
-        state["position_seconds"] = 0
-        state["is_playing"] = True
-        state["transport_state"] = "PLAYING"
-        await update_renderer_state_db(db, udn, state)
-        reset_history_tracker(udn)
-
-        # Stop existing monitor cleanly
-        if udn in playback_monitors:
-            playback_monitors[udn].cancel()
-            try:
-                await asyncio.wait([playback_monitors[udn]], timeout=1)
-            except Exception:
-                pass
-
-        _mark_monitor_starting(udn)
-        try:
-            await upnp.play_track(track["id"], track["path"], track)
-            # Start fresh monitor (only for UPnP)
-            start_monitor_task(udn)
-            last_track_start_time[udn] = time.time()
-        finally:
-            _clear_monitor_starting(udn)
-
-        return {"status": "streaming_started", "renderer": udn}
-    else:
-        state = await get_renderer_state_db(db, udn)
-        existing_queue = state.get("queue") or []
-        try:
-            current_index = next(
-                i for i, t in enumerate(existing_queue) if t.get("id") == track["id"]
-            )
-            existing_queue[current_index] = track
-        except StopIteration:
-            existing_queue = [track]
-            current_index = 0
-
-        state["queue"] = existing_queue
-        state["current_index"] = current_index
-        state["position_seconds"] = 0
-        state["is_playing"] = True
-        state["transport_state"] = "PLAYING"
-        await update_renderer_state_db(db, udn, state)
-
-        return {"status": "local_playback", "message": "Handle playback in browser"}
+    return await renderer_orchestrator.play_track(
+        db,
+        client_id,
+        track,
+        user_row["id"],
+        request,
+    )
 
 
 @router.post(
@@ -817,20 +579,7 @@ async def play_track(
 )
 async def pause_playback(client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-
-        state = await get_renderer_state_db(db, udn)
-        state["is_playing"] = False
-        await update_renderer_state_db(db, udn, state)
-
-        if not udn.startswith("local:"):
-            await upnp.set_renderer(udn)
-            await upnp.pause()
-
-            if udn in playback_monitors:
-                playback_monitors[udn].cancel()
-                del playback_monitors[udn]
-
+        await renderer_orchestrator.pause(db, client_id)
         return {"status": "ok"}
 
 
@@ -840,21 +589,7 @@ async def pause_playback(client_id: str = Depends(get_client_id)):
 )
 async def resume_playback(client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-
-        state = await get_renderer_state_db(db, udn)
-        state["is_playing"] = True
-        await update_renderer_state_db(db, udn, state)
-
-        if not udn.startswith("local:"):
-            await upnp.set_renderer(udn)
-            await upnp.resume()
-
-            if udn not in playback_monitors or playback_monitors[udn].done():
-                playback_monitors[udn] = asyncio.create_task(monitor_upnp_playback(udn))
-                import time
-
-                monitor_start_times[udn] = time.time()
+        await renderer_orchestrator.resume(db, client_id)
 
     return {"status": "ok"}
 
@@ -870,16 +605,7 @@ async def set_volume(data: dict, client_id: str = Depends(get_client_id)):
     percent = max(0, min(100, int(percent)))
 
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-
-        # Persist volume
-        state = await get_renderer_state_db(db, udn)
-        state["volume"] = percent
-        await update_renderer_state_db(db, udn, state)
-
-        if not udn.startswith("local:"):
-            await upnp.set_renderer(udn)
-            await upnp.set_volume(percent)
+        await renderer_orchestrator.set_volume(db, client_id, percent)
 
     return {"status": "ok", "percent": percent}
 
@@ -894,18 +620,10 @@ async def seek_track(data: dict, client_id: str = Depends(get_client_id)):
         raise HTTPException(status_code=400, detail="Missing seconds")
 
     async for db in get_db():
-        udn = await get_active_renderer(db, client_id)
-
-        state = await get_renderer_state_db(db, udn)
-        state["position_seconds"] = float(seconds)
-        await update_renderer_state_db(db, udn, state)
-
-        if not udn.startswith("local:"):
-            await upnp.set_renderer(udn)
-            await upnp.seek(float(seconds))
+        target = await renderer_orchestrator.seek(db, client_id, float(seconds))
+        if target == "remote":
             return {"status": "ok", "target": seconds}
-        else:
-            return {"status": "local", "message": "Handle seek in browser"}
+        return {"status": "local", "message": "Handle seek in browser"}
 
 
 @router.post(
@@ -916,7 +634,7 @@ async def add_manual_renderer(data: dict):
     ip = data.get("ip")
     if not ip:
         raise HTTPException(status_code=400, detail="Missing ip")
-    found = await upnp.add_device_by_ip(ip)
+    found = await renderer_orchestrator.add_manual(ip)
     if found:
         return {"status": "found"}
     else:
@@ -930,6 +648,8 @@ if not is_production():
         dependencies=[Depends(get_current_admin_user_jwt)],
     )
     async def debug_info():
+        upnp_backend = renderer_orchestrator.registry.backends.get("upnp")
+        upnp_manager = getattr(upnp_backend, "manager", None)
         monitors_status = {}
         for udn, task in playback_monitors.items():
             monitors_status[udn] = {
@@ -944,10 +664,10 @@ if not is_production():
                     monitors_status[udn]["error"] = str(e)
 
         return {
-            "log": upnp.debug_log,
-            "renderers": upnp.renderers,
-            "dmr_devices_keys": list(upnp.dmr_devices.keys()),
-            "local_ip": upnp.local_ip,
+            "log": getattr(upnp_manager, "debug_log", []),
+            "renderers": getattr(upnp_manager, "renderers", {}),
+            "dmr_devices_keys": list(getattr(upnp_manager, "dmr_devices", {}).keys()),
+            "local_ip": getattr(upnp_manager, "local_ip", None),
             "monitors": monitors_status,
             "monitor_start_times": monitor_start_times,
         }
@@ -957,6 +677,8 @@ if not is_production():
         dependencies=[Depends(get_current_admin_user_jwt)],
     )
     async def test_upnp():
-        if not upnp.active_renderer:
+        upnp_backend = renderer_orchestrator.registry.backends.get("upnp")
+        upnp_manager = getattr(upnp_backend, "manager", None)
+        if not getattr(upnp_manager, "active_renderer", None):
             return {"error": "No active renderer"}
         return {"status": "ok", "message": "Check debug logs"}

--- a/app/api/player.py
+++ b/app/api/player.py
@@ -64,8 +64,9 @@ async def get_player_state(client_id: str = Depends(get_client_id)):
         renderer_id, udn = await renderer_orchestrator.get_active(db, client_id)
         state = await get_renderer_state_db(db, udn)
 
-        # If UPnP, sync live state
-        if udn != f"local:{client_id}" and not udn.startswith("local:"):
+        # UPnP uses the legacy polling monitor. Event-capable backends like Cast
+        # update state through the renderer orchestrator callback path.
+        if renderer_id.startswith("upnp:"):
             # For UPnP devices, we might want to check if monitor is running
             if state["is_playing"]:
                 if udn not in playback_monitors or playback_monitors[udn].done():
@@ -75,6 +76,8 @@ async def get_player_state(client_id: str = Depends(get_client_id)):
                     if now - last_start > 5 and not _is_monitor_starting(udn):
                         logger.info(f"[Player] Auto-restarting monitor for {udn}")
                         start_monitor_task(udn)
+        elif not renderer_id.startswith("local:"):
+            state = await renderer_orchestrator.sync_status(db, renderer_id, udn, state)
 
         queue = state["queue"]
         track_ids = [

--- a/app/api/stream.py
+++ b/app/api/stream.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from app.db import get_db
 from app.api.deps import get_current_user_jwt, get_optional_user_jwt
 from app.auth_tokens import create_stream_token, verify_stream_token
+from app.services.renderer.token_policy import stream_token_ttl_seconds
 import asyncpg
 import os
 from typing import Optional
@@ -15,13 +17,20 @@ import mimetypes  # noqa: E402
 @router.get("/api/stream-url/{track_id}")
 async def get_stream_url(
     track_id: int,
+    renderer_kind: Optional[str] = None,
     user: asyncpg.Record = Depends(get_current_user_jwt),
     db: asyncpg.Connection = Depends(get_db),
 ):
-    exists = await db.fetchval("SELECT 1 FROM track WHERE id = $1", track_id)
-    if not exists:
+    row = await db.fetchrow("SELECT duration_seconds FROM track WHERE id = $1", track_id)
+    if not row:
         raise HTTPException(status_code=404, detail="Track not found")
-    token = create_stream_token(track_id=track_id, user_id=user["id"])
+    ttl_seconds = stream_token_ttl_seconds(renderer_kind, row["duration_seconds"])
+    expires_delta = timedelta(seconds=ttl_seconds) if ttl_seconds is not None else None
+    token = create_stream_token(
+        track_id=track_id,
+        user_id=user["id"],
+        expires_delta=expires_delta,
+    )
     return {"url": f"/api/stream/{track_id}?token={token}"}
 
 

--- a/app/db.py
+++ b/app/db.py
@@ -201,6 +201,9 @@ async def init_db():
                 id BIGSERIAL PRIMARY KEY,
                 friendly_name TEXT,
                 udn TEXT UNIQUE NOT NULL,
+                kind TEXT DEFAULT 'upnp',
+                native_id TEXT,
+                renderer_id TEXT UNIQUE,
                 location_url TEXT,
                 ip TEXT,
                 control_url TEXT,
@@ -219,15 +222,74 @@ async def init_db():
                 icon_mime TEXT,
                 icon_width INTEGER,
                 icon_height INTEGER,
+                cast_uuid TEXT UNIQUE,
+                cast_type TEXT,
+                last_discovered_by TEXT DEFAULT 'server',
+                available BOOLEAN DEFAULT TRUE,
+                enabled_by_default BOOLEAN DEFAULT TRUE,
+                renderer_metadata JSONB DEFAULT '{}'::jsonb,
                 last_seen_at TIMESTAMPTZ DEFAULT NOW()
             );
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS kind TEXT DEFAULT 'upnp';
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS native_id TEXT;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS renderer_id TEXT;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS cast_uuid TEXT;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS cast_type TEXT;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS last_discovered_by TEXT DEFAULT 'server';
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS enabled_by_default BOOLEAN DEFAULT TRUE;
+            ALTER TABLE renderer ADD COLUMN IF NOT EXISTS renderer_metadata JSONB DEFAULT '{}'::jsonb;
+            UPDATE renderer
+            SET
+                kind = COALESCE(kind, 'upnp'),
+                native_id = COALESCE(native_id, udn),
+                renderer_id = COALESCE(renderer_id, 'upnp:' || udn),
+                last_discovered_by = COALESCE(last_discovered_by, 'server'),
+                available = COALESCE(available, TRUE),
+                enabled_by_default = COALESCE(enabled_by_default, TRUE),
+                renderer_metadata = COALESCE(renderer_metadata, '{}'::jsonb)
+            WHERE udn IS NOT NULL;
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint c
+                    JOIN pg_class t ON t.oid = c.conrelid
+                    JOIN pg_attribute a
+                      ON a.attrelid = t.oid
+                     AND a.attnum = ANY(c.conkey)
+                    WHERE t.relname = 'renderer'
+                      AND c.contype = 'u'
+                      AND a.attname = 'renderer_id'
+                ) THEN
+                    ALTER TABLE renderer
+                        ADD CONSTRAINT renderer_renderer_id_unique UNIQUE (renderer_id);
+                END IF;
+            END $$;
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_renderer_renderer_id
+                ON renderer(renderer_id)
+                WHERE renderer_id IS NOT NULL;
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_renderer_cast_uuid
+                ON renderer(cast_uuid)
+                WHERE cast_uuid IS NOT NULL;
             
             -- Client sessions
             CREATE TABLE IF NOT EXISTS client_session (
                 client_id TEXT PRIMARY KEY,
                 active_renderer_udn TEXT,
+                active_renderer_id TEXT,
                 last_seen_at TIMESTAMPTZ DEFAULT NOW()
             );
+            ALTER TABLE client_session ADD COLUMN IF NOT EXISTS active_renderer_id TEXT;
+            UPDATE client_session
+            SET active_renderer_id = CASE
+                WHEN active_renderer_udn IS NULL THEN NULL
+                WHEN active_renderer_udn LIKE 'local:%' THEN active_renderer_udn
+                WHEN active_renderer_udn LIKE 'upnp:%' THEN active_renderer_udn
+                WHEN active_renderer_udn LIKE 'cast:%' THEN active_renderer_udn
+                ELSE 'upnp:' || active_renderer_udn
+            END
+            WHERE active_renderer_id IS NULL;
             
             -- Renderer state
             CREATE TABLE IF NOT EXISTS renderer_state (

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from app.security import configure_security_middleware, fastapi_docs_config, is_
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
-    from app.upnp import UPnPManager
+    from app.services.renderer import get_renderer_registry
     from app.scanner.scan_manager import ScanManager
     from app.scanner.dns_resolver import warm_dns_cache
     from app.scheduler import Scheduler
@@ -17,13 +17,14 @@ async def lifespan(app: FastAPI):
     # Critical: Warm DNS cache and install monkey-patch BEFORE any clients are created
     await warm_dns_cache()
 
-    UPnPManager.get_instance().start_background_scan()
+    renderer_registry = get_renderer_registry()
+    await renderer_registry.start_all()
     # ScanManager is lazy initialized but good to have it ready
     ScanManager.get_instance()
     await Scheduler.get_instance().start()
     yield
     await Scheduler.get_instance().stop()
-    await UPnPManager.get_instance().stop_background_scan()
+    await renderer_registry.stop_all()
     await ScanManager.get_instance().shutdown()
     await close_db()
 

--- a/app/models/player.py
+++ b/app/models/player.py
@@ -31,6 +31,8 @@ class PlayerState(BaseModel):
     position_seconds: float
     is_playing: bool
     renderer: str  # UDN
+    renderer_id: Optional[str] = None
+    renderer_kind: Optional[str] = None
     transport_state: Optional[str] = "STOPPED"
     volume: Optional[int] = None
 

--- a/app/services/player/state.py
+++ b/app/services/player/state.py
@@ -95,17 +95,18 @@ def strip_art_ids(queue: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 async def get_active_renderer(db: asyncpg.Connection, client_id: str) -> str:
     """Get active renderer UDN for client. Defaults to local:<client_id>."""
     row = await db.fetchrow(
-        "SELECT active_renderer_udn FROM client_session WHERE client_id = $1", client_id
+        "SELECT active_renderer_udn, active_renderer_id FROM client_session WHERE client_id = $1",
+        client_id,
     )
-    if row and row[0]:
-        return row[0]
+    if row and row["active_renderer_udn"]:
+        return row["active_renderer_udn"]
 
     # If no session found, implicitly create one for observability
     default_udn = f"local:{client_id}"
     await db.execute(
         """
-        INSERT INTO client_session (client_id, active_renderer_udn, last_seen_at)
-        VALUES ($1, $2, NOW())
+        INSERT INTO client_session (client_id, active_renderer_udn, active_renderer_id, last_seen_at)
+        VALUES ($1, $2, $2, NOW())
         ON CONFLICT (client_id) DO NOTHING
     """,
         client_id,

--- a/app/services/player/state.py
+++ b/app/services/player/state.py
@@ -160,7 +160,7 @@ async def get_renderer_state_db(db: asyncpg.Connection, udn: str) -> Dict[str, A
 async def update_renderer_state_db(
     db: asyncpg.Connection, udn: str, state: Dict[str, Any]
 ):
-    """Upsert renderer state."""
+    """Upsert renderer state (all fields)."""
     queue_json = json.dumps(strip_art_ids(state.get("queue", [])))
     volume = state.get("volume")
     await db.execute(
@@ -183,4 +183,44 @@ async def update_renderer_state_db(
         bool(state.get("is_playing")),
         state.get("transport_state", "STOPPED"),
         volume,
+    )
+
+
+async def update_playback_progress_db(
+    db: asyncpg.Connection, udn: str, state: Dict[str, Any]
+):
+    """Update only progress fields — never current_index or queue.
+    Safe to call concurrently from status listeners and polling.
+    """
+    await db.execute(
+        """
+        INSERT INTO renderer_state (renderer_udn, queue, current_index, position_seconds, is_playing, transport_state, volume, updated_at)
+        VALUES ($1, '[]'::jsonb, 0, $2, $3, $4, $5, NOW())
+        ON CONFLICT(renderer_udn) DO UPDATE SET
+            position_seconds = excluded.position_seconds,
+            is_playing = excluded.is_playing,
+            transport_state = excluded.transport_state,
+            volume = excluded.volume,
+            updated_at = NOW()
+    """,
+        udn,
+        state.get("position_seconds", 0),
+        bool(state.get("is_playing")),
+        state.get("transport_state", "STOPPED"),
+        state.get("volume"),
+    )
+
+
+async def update_queue_logged_db(
+    db: asyncpg.Connection, udn: str, state: Dict[str, Any]
+):
+    """Update only the queue column (used after setting track logged flag)."""
+    queue_json = json.dumps(strip_art_ids(state.get("queue", [])))
+    await db.execute(
+        """
+        UPDATE renderer_state SET queue = $2, updated_at = NOW()
+        WHERE renderer_udn = $1
+    """,
+        udn,
+        queue_json,
     )

--- a/app/services/renderer/__init__.py
+++ b/app/services/renderer/__init__.py
@@ -1,0 +1,4 @@
+from app.services.renderer.orchestrator import get_renderer_orchestrator
+from app.services.renderer.registry import get_renderer_registry
+
+__all__ = ["get_renderer_orchestrator", "get_renderer_registry"]

--- a/app/services/renderer/cast_backend.py
+++ b/app/services/renderer/cast_backend.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import mimetypes
+import os
+import threading
+import time
+from datetime import timedelta
+from typing import Any, Awaitable, Callable
+
+from app.auth_tokens import create_stream_token
+from app.services.renderer.contracts import (
+    PlaybackContext,
+    RendererBackend,
+    RendererCapabilities,
+    RendererDevice,
+    RendererStatus,
+    make_renderer_id,
+    split_renderer_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _CastStatusListener:
+    def __init__(
+        self,
+        backend: "CastRendererBackend",
+        renderer_id: str,
+        callback: Callable[[RendererStatus], Awaitable[None]],
+    ) -> None:
+        self.backend = backend
+        self.renderer_id = renderer_id
+        self.callback = callback
+        self.last_state = "UNKNOWN"
+        self.started_at = time.time()
+
+    def new_media_status(self, status: Any) -> None:
+        renderer_status = self.backend.status_from_media_status(
+            self.renderer_id,
+            status,
+            previous_state=self.last_state,
+            started_at=self.started_at,
+        )
+        self.last_state = renderer_status.state
+        self.backend.dispatch_status_callback(self.callback, renderer_status)
+
+
+class CastRendererBackend(RendererBackend):
+    kind = "cast"
+
+    def __init__(
+        self,
+        known_hosts: list[str] | None = None,
+        discovery_timeout: float = 5,
+        launch_timeout: float = 10,
+        chromecast_getter: Callable[..., Any] | None = None,
+    ) -> None:
+        self.known_hosts = known_hosts if known_hosts is not None else self._known_hosts_from_env()
+        self.discovery_timeout = discovery_timeout
+        self.launch_timeout = launch_timeout
+        self.chromecast_getter = chromecast_getter
+        self.browser: Any | None = None
+        self.casts: dict[str, Any] = {}
+        self.devices: dict[str, RendererDevice] = {}
+        self._listeners: dict[str, list[_CastStatusListener]] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._discovery_lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        try:
+            await self.discover(refresh=True)
+        except Exception as exc:
+            logger.warning("Cast startup discovery failed: %s", exc)
+
+    async def stop(self) -> None:
+        browser = self.browser
+        self.browser = None
+        if browser and hasattr(browser, "stop_discovery"):
+            await asyncio.to_thread(browser.stop_discovery)
+        for cast in list(self.casts.values()):
+            if hasattr(cast, "disconnect"):
+                try:
+                    await asyncio.to_thread(cast.disconnect, 1)
+                except Exception:
+                    logger.debug("Error disconnecting Cast device", exc_info=True)
+
+    async def discover(self, refresh: bool = False) -> list[RendererDevice]:
+        if refresh or not self.devices:
+            async with self._discovery_lock:
+                casts, browser = await asyncio.to_thread(self._get_chromecasts_blocking)
+                if browser:
+                    old_browser = self.browser
+                    self.browser = browser
+                    if old_browser and old_browser is not browser and hasattr(old_browser, "stop_discovery"):
+                        await asyncio.to_thread(old_browser.stop_discovery)
+                for cast in casts:
+                    self._register_cast(cast)
+        return await self.list_devices()
+
+    async def add_manual(self, address: str) -> RendererDevice | None:
+        casts, browser = await asyncio.to_thread(
+            self._get_chromecasts_blocking,
+            [address],
+            self.discovery_timeout,
+        )
+        if browser and hasattr(browser, "stop_discovery"):
+            await asyncio.to_thread(browser.stop_discovery)
+        for cast in casts:
+            device = self._register_cast(cast)
+            if device.ip == address:
+                return device
+        return self._device_matching_address(address)
+
+    async def list_devices(self) -> list[RendererDevice]:
+        return sorted(self.devices.values(), key=lambda device: device.name.lower())
+
+    async def unload_device(self, renderer_id: str) -> None:
+        _, uuid = split_renderer_id(renderer_id)
+        cast = self.casts.pop(uuid, None)
+        self.devices.pop(uuid, None)
+        self._listeners.pop(renderer_id, None)
+        if cast and hasattr(cast, "disconnect"):
+            await asyncio.to_thread(cast.disconnect, 1)
+
+    async def play_track(
+        self,
+        renderer_id: str,
+        track: dict[str, Any],
+        context: PlaybackContext,
+    ) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        await asyncio.to_thread(cast.start_app, self._media_receiver_app_id(), True, self.launch_timeout)
+        media_url = self._stream_url(track, context)
+        mime_type = self._mime_type(track)
+        metadata = self._media_metadata(track, context)
+        thumb = self._art_url(track, context)
+        logger.info(
+            "Cast play requested renderer=%s track_id=%s mime=%s url=%s",
+            renderer_id,
+            track.get("id"),
+            mime_type,
+            media_url.split("?", 1)[0],
+        )
+        await asyncio.to_thread(
+            cast.media_controller.play_media,
+            media_url,
+            mime_type,
+            title=track.get("title") or "Unknown Track",
+            thumb=thumb,
+            metadata=metadata,
+            stream_type=self._stream_type(),
+            callback_function=self._load_callback(renderer_id, int(track["id"])),
+        )
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING", current_media_url=media_url)
+
+    async def pause(self, renderer_id: str) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        await asyncio.to_thread(cast.media_controller.pause)
+        return RendererStatus(renderer_id=renderer_id, state="PAUSED")
+
+    async def resume(self, renderer_id: str) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        await asyncio.to_thread(cast.media_controller.play)
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING")
+
+    async def stop_playback(self, renderer_id: str) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        try:
+            await asyncio.to_thread(cast.media_controller.stop)
+        except Exception:
+            logger.debug("Cast media stop failed for %s", renderer_id, exc_info=True)
+        if hasattr(cast, "quit_app"):
+            try:
+                await asyncio.to_thread(cast.quit_app, self.launch_timeout)
+            except Exception:
+                logger.debug("Cast app quit failed for %s", renderer_id, exc_info=True)
+        return RendererStatus(renderer_id=renderer_id, state="STOPPED")
+
+    async def seek(self, renderer_id: str, seconds: float) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        await asyncio.to_thread(cast.media_controller.seek, seconds)
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING", position_seconds=seconds)
+
+    async def set_volume(self, renderer_id: str, percent: int) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        bounded = max(0, min(100, int(percent)))
+        await asyncio.to_thread(cast.set_volume, bounded / 100.0)
+        return RendererStatus(renderer_id=renderer_id, state="UNKNOWN", volume_percent=bounded)
+
+    async def mute(self, renderer_id: str, muted: bool) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        await asyncio.to_thread(cast.set_volume_muted, muted)
+        return RendererStatus(renderer_id=renderer_id, state="UNKNOWN", volume_muted=muted)
+
+    async def get_status(self, renderer_id: str) -> RendererStatus:
+        cast = await self._get_ready_cast(renderer_id)
+        controller = cast.media_controller
+        await asyncio.to_thread(self._refresh_controller_status, controller, renderer_id)
+        status = getattr(controller, "status", None)
+        return self.status_from_media_status(renderer_id, status, trust_idle=True)
+
+    def register_status_listener(
+        self,
+        renderer_id: str,
+        callback: Callable[[RendererStatus], Awaitable[None]],
+    ) -> Callable[[], None]:
+        _, uuid = split_renderer_id(renderer_id)
+        cast = self.casts[uuid]
+        listener = _CastStatusListener(self, renderer_id, callback)
+        cast.media_controller.register_status_listener(listener)
+        self._listeners.setdefault(renderer_id, []).append(listener)
+
+        def unsubscribe() -> None:
+            try:
+                cast.media_controller._status_listeners.remove(listener)
+            except (ValueError, AttributeError):
+                pass
+            try:
+                self._listeners.get(renderer_id, []).remove(listener)
+            except ValueError:
+                pass
+
+        return unsubscribe
+
+    def dispatch_status_callback(
+        self,
+        callback: Callable[[RendererStatus], Awaitable[None]],
+        status: RendererStatus,
+    ) -> None:
+        loop = self._loop
+        if loop and loop.is_running():
+            loop.call_soon_threadsafe(lambda: asyncio.create_task(callback(status)))
+            return
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        running_loop.create_task(callback(status))
+
+    def status_from_media_status(
+        self,
+        renderer_id: str,
+        status: Any,
+        previous_state: str = "UNKNOWN",
+        started_at: float | None = None,
+        *,
+        trust_idle: bool = False,
+    ) -> RendererStatus:
+        player_state = getattr(status, "player_state", None)
+        state = self.normalize_player_state(player_state)
+        current_time = getattr(status, "adjusted_current_time", None)
+        if current_time is None:
+            current_time = getattr(status, "current_time", 0) or 0
+        duration = getattr(status, "duration", None)
+        volume = getattr(status, "volume_level", None)
+        ended = (
+            state == "IDLE"
+            and previous_state == "PLAYING"
+            and (started_at is None or time.time() - started_at > 3)
+        )
+        if state == "IDLE" and not ended and not trust_idle:
+            state = "UNKNOWN"
+        return RendererStatus(
+            renderer_id=renderer_id,
+            state=state,
+            position_seconds=float(current_time or 0),
+            duration_seconds=float(duration) if duration is not None else None,
+            volume_percent=round(float(volume) * 100) if volume is not None else None,
+            volume_muted=getattr(status, "volume_muted", None),
+            current_media_url=getattr(status, "content_id", None),
+            ended=ended,
+        )
+
+    @staticmethod
+    def normalize_player_state(player_state: str | None) -> str:
+        if player_state in {"PLAYING", "BUFFERING"}:
+            return "PLAYING"
+        if player_state == "PAUSED":
+            return "PAUSED"
+        if player_state == "IDLE":
+            return "IDLE"
+        return "UNKNOWN"
+
+    def _get_chromecasts_blocking(
+        self,
+        known_hosts: list[str] | None = None,
+        discovery_timeout: float | None = None,
+    ) -> tuple[list[Any], Any | None]:
+        getter = self.chromecast_getter
+        if getter is None:
+            import pychromecast
+
+            getter = pychromecast.get_chromecasts
+        result = getter(
+            tries=1,
+            timeout=5,
+            retry_wait=1,
+            blocking=True,
+            known_hosts=known_hosts if known_hosts is not None else self.known_hosts,
+        )
+        if isinstance(result, tuple):
+            return result
+        return [], result
+
+    def _register_cast(self, cast: Any) -> RendererDevice:
+        uuid = str(getattr(cast, "uuid", None) or getattr(getattr(cast, "cast_info", None), "uuid"))
+        device = RendererDevice(
+            renderer_id=make_renderer_id(self.kind, uuid),
+            kind=self.kind,
+            native_id=uuid,
+            udn=make_renderer_id(self.kind, uuid),
+            name=getattr(cast, "name", None)
+            or getattr(getattr(cast, "cast_info", None), "friendly_name", None)
+            or "Cast Renderer",
+            ip=self._cast_ip(cast),
+            manufacturer=getattr(getattr(cast, "cast_info", None), "manufacturer", None),
+            model_name=getattr(cast, "model_name", None)
+            or getattr(getattr(cast, "cast_info", None), "model_name", None),
+            cast_type=getattr(cast, "cast_type", None)
+            or getattr(getattr(cast, "cast_info", None), "cast_type", None),
+            discovered_by="server",
+            capabilities=RendererCapabilities(
+                can_mute=True,
+                supports_events=True,
+                supported_mime_types={"audio/flac", "audio/mpeg", "audio/mp4", "audio/wav", "audio/ogg"},
+            ),
+            is_group=(getattr(cast, "cast_type", None) == "group"),
+        )
+        self.casts[uuid] = cast
+        self.devices[uuid] = device
+        return device
+
+    async def _get_ready_cast(self, renderer_id: str) -> Any:
+        _, uuid = split_renderer_id(renderer_id)
+        cast = self.casts.get(uuid)
+        if not cast:
+            await self.discover(refresh=True)
+            cast = self.casts.get(uuid)
+        if not cast:
+            raise ValueError(f"Cast renderer {renderer_id} not found")
+        await asyncio.to_thread(cast.wait, 10)
+        return cast
+
+    def _device_matching_address(self, address: str) -> RendererDevice | None:
+        for device in self.devices.values():
+            if device.ip == address or device.native_id == address:
+                return device
+        return None
+
+    @staticmethod
+    def _known_hosts_from_env() -> list[str]:
+        raw = os.getenv("CAST_KNOWN_HOSTS", "")
+        return [item.strip() for item in raw.split(",") if item.strip()]
+
+    @staticmethod
+    def _cast_ip(cast: Any) -> str | None:
+        cast_info = getattr(cast, "cast_info", None)
+        if getattr(cast_info, "host", None):
+            return cast_info.host
+        uri = getattr(cast, "uri", "")
+        return uri.split(":", 1)[0] if uri else None
+
+    @staticmethod
+    def _refresh_controller_status(controller: Any, renderer_id: str, timeout: float = 1.0) -> None:
+        if not hasattr(controller, "update_status"):
+            return
+        done = threading.Event()
+
+        def callback(success: bool, response: dict[str, Any] | None) -> None:
+            done.set()
+
+        try:
+            controller.update_status(callback_function=callback)
+            done.wait(timeout)
+        except Exception:
+            logger.debug("Cast status refresh failed for %s", renderer_id, exc_info=True)
+
+    @staticmethod
+    def _media_receiver_app_id() -> str:
+        try:
+            from pychromecast.controllers.media import APP_MEDIA_RECEIVER
+
+            return APP_MEDIA_RECEIVER
+        except Exception:
+            return "CC1AD845"
+
+    @staticmethod
+    def _stream_type() -> str:
+        try:
+            from pychromecast.controllers.media import STREAM_TYPE_BUFFERED
+
+            return STREAM_TYPE_BUFFERED
+        except Exception:
+            return "BUFFERED"
+
+    @staticmethod
+    def _mime_type(track: dict[str, Any]) -> str:
+        mime_type = track.get("mime")
+        if mime_type:
+            return mime_type
+        guessed, _ = mimetypes.guess_type(track.get("path") or "")
+        return guessed or "audio/flac"
+
+    @staticmethod
+    def _stream_url(track: dict[str, Any], context: PlaybackContext) -> str:
+        expires_delta = (
+            timedelta(seconds=context.token_ttl_seconds)
+            if context.token_ttl_seconds
+            else None
+        )
+        token = create_stream_token(
+            int(track["id"]),
+            user_id=context.user_id or track.get("user_id"),
+            expires_delta=expires_delta,
+        )
+        return f"{context.base_url}/api/stream/{track['id']}?token={token}"
+
+    @staticmethod
+    def _art_url(track: dict[str, Any], context: PlaybackContext) -> str | None:
+        if not track.get("art_sha1"):
+            return None
+        return f"{context.base_url}/art/file/{track['art_sha1']}?max_size=600"
+
+    def _media_metadata(self, track: dict[str, Any], context: PlaybackContext) -> dict[str, Any]:
+        images = []
+        art_url = self._art_url(track, context)
+        if art_url:
+            images.append({"url": art_url})
+        return {
+            "metadataType": 3,
+            "title": track.get("title") or "Unknown Track",
+            "artist": track.get("artist") or self._artists_text(track),
+            "albumName": track.get("album") or "",
+            "images": images,
+        }
+
+    @staticmethod
+    def _artists_text(track: dict[str, Any]) -> str:
+        artists = track.get("artists") or []
+        if isinstance(artists, list):
+            return ", ".join(item.get("name", "") for item in artists if isinstance(item, dict)) or "Unknown Artist"
+        return str(artists or "Unknown Artist")
+
+    @staticmethod
+    def _load_callback(renderer_id: str, track_id: int) -> Callable[[bool, dict[str, Any] | None], None]:
+        def callback(success: bool, response: dict[str, Any] | None) -> None:
+            if success:
+                logger.info("Cast load accepted renderer=%s track_id=%s", renderer_id, track_id)
+            else:
+                logger.warning(
+                    "Cast load failed renderer=%s track_id=%s response=%s",
+                    renderer_id,
+                    track_id,
+                    response,
+                )
+
+        return callback

--- a/app/services/renderer/contracts.py
+++ b/app/services/renderer/contracts.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Protocol
+
+
+KNOWN_RENDERER_KINDS = {
+    "upnp",
+    "cast",
+    "chromecast",
+    "airplay",
+    "local",
+    "local_audio",
+    "universal",
+    "sync_group",
+}
+
+
+@dataclass
+class RendererCapabilities:
+    can_play: bool = True
+    can_pause: bool = True
+    can_stop: bool = True
+    can_seek: bool = True
+    can_set_volume: bool = True
+    can_mute: bool = False
+    can_next_previous: bool = False
+    can_enqueue: bool = False
+    can_group: bool = False
+    can_power: bool = False
+    reports_progress: bool = True
+    supports_events: bool = False
+    requires_flow_mode: bool = False
+    supported_mime_types: set[str] = field(default_factory=set)
+
+    def as_dict(self) -> dict[str, Any]:
+        data = self.__dict__.copy()
+        data["supported_mime_types"] = sorted(self.supported_mime_types)
+        return data
+
+
+@dataclass
+class RendererDevice:
+    renderer_id: str
+    kind: str
+    native_id: str
+    name: str
+    udn: str | None = None
+    ip: str | None = None
+    manufacturer: str | None = None
+    model_name: str | None = None
+    cast_type: str | None = None
+    discovered_by: str = "server"
+    capabilities: RendererCapabilities = field(default_factory=RendererCapabilities)
+    available: bool = True
+    enabled_by_default: bool = True
+    is_group: bool = False
+    group_members: list[str] = field(default_factory=list)
+
+    def as_api_dict(self) -> dict[str, Any]:
+        return {
+            "renderer_id": self.renderer_id,
+            "kind": self.kind,
+            "native_id": self.native_id,
+            "udn": self.udn or self.native_id,
+            "name": self.name,
+            "type": self.kind,
+            "ip": self.ip,
+            "manufacturer": self.manufacturer,
+            "model_name": self.model_name,
+            "cast_type": self.cast_type,
+            "discovered_by": self.discovered_by,
+            "capabilities": self.capabilities.as_dict(),
+            "available": self.available,
+            "enabled_by_default": self.enabled_by_default,
+            "is_group": self.is_group,
+            "group_members": self.group_members,
+        }
+
+
+@dataclass
+class RendererStatus:
+    renderer_id: str
+    state: str
+    position_seconds: float = 0
+    duration_seconds: float | None = None
+    volume_percent: int | None = None
+    volume_muted: bool | None = None
+    current_track_id: int | None = None
+    current_media_url: str | None = None
+    active_source: str | None = None
+    available: bool = True
+    ended: bool = False
+
+
+@dataclass
+class PlaybackContext:
+    base_url: str
+    user_id: int | None
+    username: str | None = None
+    token_ttl_seconds: int | None = None
+
+
+class RendererBackend(Protocol):
+    kind: str
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def discover(self, refresh: bool = False) -> list[RendererDevice]: ...
+    async def add_manual(self, address: str) -> RendererDevice | None: ...
+    async def list_devices(self) -> list[RendererDevice]: ...
+    async def unload_device(self, renderer_id: str) -> None: ...
+    async def play_track(
+        self,
+        renderer_id: str,
+        track: dict[str, Any],
+        context: PlaybackContext,
+    ) -> RendererStatus: ...
+    async def pause(self, renderer_id: str) -> RendererStatus: ...
+    async def resume(self, renderer_id: str) -> RendererStatus: ...
+    async def stop_playback(self, renderer_id: str) -> RendererStatus: ...
+    async def seek(self, renderer_id: str, seconds: float) -> RendererStatus: ...
+    async def set_volume(self, renderer_id: str, percent: int) -> RendererStatus: ...
+    async def mute(self, renderer_id: str, muted: bool) -> RendererStatus: ...
+    async def get_status(self, renderer_id: str) -> RendererStatus: ...
+
+
+class SupportsStatusEvents(Protocol):
+    def register_status_listener(
+        self,
+        renderer_id: str,
+        callback: Callable[[RendererStatus], Awaitable[None]],
+    ) -> Callable[[], None]: ...
+
+
+def make_renderer_id(kind: str, native_id: str) -> str:
+    if native_id.startswith(f"{kind}:"):
+        return native_id
+    return f"{kind}:{native_id}"
+
+
+def split_renderer_id(renderer_id: str) -> tuple[str, str]:
+    if ":" not in renderer_id:
+        return "upnp", renderer_id
+    kind, native_id = renderer_id.split(":", 1)
+    if not kind or not native_id:
+        raise ValueError(f"Invalid renderer_id: {renderer_id}")
+    if kind not in KNOWN_RENDERER_KINDS:
+        return "upnp", renderer_id
+    return kind, native_id
+
+
+def is_local_renderer(renderer_id: str) -> bool:
+    return renderer_id.startswith("local:")

--- a/app/services/renderer/contracts.py
+++ b/app/services/renderer/contracts.py
@@ -49,7 +49,13 @@ class RendererDevice:
     ip: str | None = None
     manufacturer: str | None = None
     model_name: str | None = None
+    model_number: str | None = None
+    device_type: str | None = None
     cast_type: str | None = None
+    icon_url: str | None = None
+    icon_mime: str | None = None
+    icon_width: int | None = None
+    icon_height: int | None = None
     discovered_by: str = "server"
     capabilities: RendererCapabilities = field(default_factory=RendererCapabilities)
     available: bool = True
@@ -68,7 +74,13 @@ class RendererDevice:
             "ip": self.ip,
             "manufacturer": self.manufacturer,
             "model_name": self.model_name,
+            "model_number": self.model_number,
+            "device_type": self.device_type,
             "cast_type": self.cast_type,
+            "icon_url": self.icon_url,
+            "icon_mime": self.icon_mime,
+            "icon_width": self.icon_width,
+            "icon_height": self.icon_height,
             "discovered_by": self.discovered_by,
             "capabilities": self.capabilities.as_dict(),
             "available": self.available,

--- a/app/services/renderer/orchestrator.py
+++ b/app/services/renderer/orchestrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import mimetypes
+import logging
 import os
 import time
 from typing import Any
@@ -9,8 +9,13 @@ from typing import Any
 import asyncpg
 from fastapi import HTTPException, Request
 
+from app.db import get_pool
 from app.services.player.globals import last_track_start_time, monitor_start_times, playback_monitors
-from app.services.player.history import reset_history_tracker
+from app.services.player.history import (
+    log_history,
+    reset_history_tracker,
+    should_log_history,
+)
 from app.services.player.monitor import (
     _clear_monitor_starting,
     _mark_monitor_starting,
@@ -20,16 +25,22 @@ from app.services.player.state import (
     enrich_track_metadata,
     get_renderer_state_db,
     track_path_exists,
+    update_playback_progress_db,
+    update_queue_logged_db,
     update_renderer_state_db,
 )
-from app.services.renderer.contracts import PlaybackContext, is_local_renderer
+from app.services.renderer.contracts import PlaybackContext, RendererStatus, is_local_renderer
 from app.services.renderer.registry import RendererRegistry, get_renderer_registry
 from app.services.renderer.token_policy import stream_token_ttl_seconds
+
+logger = logging.getLogger(__name__)
 
 
 class RendererOrchestrator:
     def __init__(self, registry: RendererRegistry | None = None) -> None:
         self.registry = registry or get_renderer_registry()
+        self._status_unsubscribers: dict[str, Any] = {}
+        self._last_ended_at: dict[str, float] = {}
 
     async def get_active(self, db: asyncpg.Connection, client_id: str) -> tuple[str, str]:
         return await self.registry.get_active(db, client_id)
@@ -40,7 +51,11 @@ class RendererOrchestrator:
         client_id: str,
         renderer_id_or_udn: str,
     ) -> tuple[str, str]:
-        return await self.registry.set_active(db, client_id, renderer_id_or_udn)
+        previous_renderer_id, previous_state_key = await self.get_active(db, client_id)
+        renderer_id, state_key = await self.registry.set_active(db, client_id, renderer_id_or_udn)
+        if previous_renderer_id.startswith("cast:") and previous_renderer_id != renderer_id:
+            await self._stop_previous_cast(previous_renderer_id, previous_state_key)
+        return renderer_id, state_key
 
     async def list_renderers(
         self,
@@ -113,7 +128,10 @@ class RendererOrchestrator:
         state = await get_renderer_state_db(db, state_key)
         current_track = self._current_track(state)
         if current_track and current_track.get("id") == track["id"] and state.get("is_playing"):
-            if state_key not in playback_monitors or playback_monitors[state_key].done():
+            backend = self.registry.get_backend(renderer_id)
+            if hasattr(backend, "register_status_listener"):
+                self._register_status_listener(backend, renderer_id, state_key)
+            elif state_key not in playback_monitors or playback_monitors[state_key].done():
                 start_monitor_task(state_key)
                 last_track_start_time[state_key] = time.time()
             return {"status": "already_playing", "renderer": state_key}
@@ -150,8 +168,11 @@ class RendererOrchestrator:
         state["is_playing"] = True
         await update_renderer_state_db(db, state_key, state)
         if not is_local_renderer(renderer_id):
-            await self.registry.get_backend(renderer_id).resume(renderer_id)
-            if state_key not in playback_monitors or playback_monitors[state_key].done():
+            backend = self.registry.get_backend(renderer_id)
+            await backend.resume(renderer_id)
+            if hasattr(backend, "register_status_listener"):
+                self._register_status_listener(backend, renderer_id, state_key)
+            elif state_key not in playback_monitors or playback_monitors[state_key].done():
                 start_monitor_task(state_key)
                 monitor_start_times[state_key] = time.time()
 
@@ -253,9 +274,13 @@ class RendererOrchestrator:
                     track.get("duration_seconds"),
                 ),
             )
-            await self.registry.get_backend(renderer_id).play_track(renderer_id, track, context)
-            start_monitor_task(state_key)
-            last_track_start_time[state_key] = time.time()
+            backend = self.registry.get_backend(renderer_id)
+            await backend.play_track(renderer_id, track, context)
+            if hasattr(backend, "register_status_listener"):
+                self._register_status_listener(backend, renderer_id, state_key)
+            else:
+                start_monitor_task(state_key)
+                last_track_start_time[state_key] = time.time()
         finally:
             _clear_monitor_starting(state_key)
 
@@ -268,6 +293,72 @@ class RendererOrchestrator:
                 pass
             if remove:
                 playback_monitors.pop(state_key, None)
+
+    async def _stop_previous_cast(self, renderer_id: str, state_key: str) -> None:
+        unsubscribe = self._status_unsubscribers.pop(state_key, None)
+        if unsubscribe:
+            try:
+                unsubscribe()
+            except Exception:
+                logger.debug("Cast status listener cleanup failed for %s", renderer_id, exc_info=True)
+        try:
+            await self.registry.get_backend(renderer_id).stop_playback(renderer_id)
+        except Exception:
+            logger.warning("Failed to close previous Cast session %s", renderer_id, exc_info=True)
+
+    async def _log_history_if_due(
+        self,
+        db: asyncpg.Connection,
+        state_key: str,
+        renderer_id: str,
+        state: dict[str, Any],
+        allow_stopped: bool = False,
+    ) -> None:
+        if not state.get("is_playing") and not allow_stopped:
+            return
+        current_index = state.get("current_index")
+        queue = state.get("queue") or []
+        if current_index is None or current_index < 0 or current_index >= len(queue):
+            return
+        track = queue[current_index]
+        if not isinstance(track, dict) or track.get("logged"):
+            return
+        track_id = track.get("id")
+        if not track_id:
+            return
+        duration = track.get("duration_seconds") or 0
+        if not should_log_history(
+            state_key, track_id, state.get("position_seconds") or 0, duration
+        ):
+            return
+        renderer_ip = await self._renderer_ip(db, renderer_id, state_key)
+        await log_history(
+            db,
+            track_id,
+            client_ip=renderer_ip or "unknown",
+            client_id=state_key,
+            user_id=track.get("user_id"),
+        )
+        track["logged"] = True
+        await update_queue_logged_db(db, state_key, state)
+
+    @staticmethod
+    async def _renderer_ip(
+        db: asyncpg.Connection,
+        renderer_id: str,
+        state_key: str,
+    ) -> str | None:
+        return await db.fetchval(
+            """
+            SELECT ip
+            FROM renderer
+            WHERE renderer_id = $1 OR udn = $2
+            ORDER BY last_seen_at DESC NULLS LAST
+            LIMIT 1
+            """,
+            renderer_id,
+            state_key,
+        )
 
     async def _first_playable_index(
         self,
@@ -289,6 +380,127 @@ class RendererOrchestrator:
         env_port = os.environ.get("HOST_PORT")
         port = env_port if env_port else ((request.url.port if request else None) or 8111)
         return f"http://{local_ip}:{port}"
+
+    def _register_status_listener(self, backend: Any, renderer_id: str, state_key: str) -> None:
+        unsubscribe = self._status_unsubscribers.pop(state_key, None)
+        if unsubscribe:
+            try:
+                unsubscribe()
+            except Exception:
+                pass
+
+        async def callback(status: RendererStatus) -> None:
+            await self.handle_status(state_key, status)
+
+        self._status_unsubscribers[state_key] = backend.register_status_listener(
+            renderer_id,
+            callback,
+        )
+
+    async def handle_status(self, state_key: str, status: RendererStatus) -> None:
+        async with get_pool().acquire() as db:
+            state = await get_renderer_state_db(db, state_key)
+            await self._apply_status(db, state_key, state, status)
+
+    async def sync_status(
+        self,
+        db: asyncpg.Connection,
+        renderer_id: str,
+        state_key: str,
+        state: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        backend = self.registry.get_backend(renderer_id)
+        try:
+            status = await backend.get_status(renderer_id)
+        except Exception:
+            logger.debug("Renderer status sync failed for %s", renderer_id, exc_info=True)
+            return state or await get_renderer_state_db(db, state_key)
+        current_state = state or await get_renderer_state_db(db, state_key)
+        return await self._apply_status(db, state_key, current_state, status)
+
+    async def _apply_status(
+        self,
+        db: asyncpg.Connection,
+        state_key: str,
+        state: dict[str, Any],
+        status: RendererStatus,
+    ) -> dict[str, Any]:
+        if status.state == "UNKNOWN" and not status.current_media_url:
+            return state
+        prev_position = state.get("position_seconds") or 0
+        if status.position_seconds is not None:
+            state["position_seconds"] = status.position_seconds
+        if status.volume_percent is not None:
+            state["volume"] = status.volume_percent
+        if status.state != "UNKNOWN":
+            state["transport_state"] = status.state
+            state["is_playing"] = status.state == "PLAYING"
+        await update_playback_progress_db(db, state_key, state)
+        await self._log_history_if_due(
+            db,
+            state_key,
+            status.renderer_id,
+            state,
+            allow_stopped=status.ended,
+        )
+        if status.ended or self._detect_track_ended(state, status, prev_position):
+            await self._advance_queue_from_status(db, state_key, state)
+            state = await get_renderer_state_db(db, state_key)
+        return state
+
+    @staticmethod
+    def _detect_track_ended(
+        state: dict[str, Any],
+        status: RendererStatus,
+        prev_position: float,
+    ) -> bool:
+        """Detect track completion from position vs duration.
+
+        Uses the larger of previous and current position because some
+        devices reset position to 0 on idle.  Only triggers when the
+        device is not actively playing or paused.
+        """
+        if status.state in ("PLAYING", "PAUSED"):
+            return False
+        queue = state.get("queue") or []
+        idx = state.get("current_index", -1)
+        if idx < 0 or idx >= len(queue):
+            return False
+        track = queue[idx]
+        if not isinstance(track, dict):
+            return False
+        duration = track.get("duration_seconds") or 0
+        if duration <= 0:
+            return False
+        position = max(prev_position, state.get("position_seconds") or 0)
+        return position >= duration - 5
+
+    async def _advance_queue_from_status(
+        self,
+        db: asyncpg.Connection,
+        state_key: str,
+        state: dict[str, Any],
+    ) -> None:
+        now = time.time()
+        if now - self._last_ended_at.get(state_key, 0) < 3:
+            return
+        self._last_ended_at[state_key] = now
+        reset_history_tracker(state_key)
+        queue = state.get("queue") or []
+        next_index = int(state.get("current_index", -1)) + 1
+        if next_index >= len(queue):
+            state["is_playing"] = False
+            state["transport_state"] = "STOPPED"
+            await update_renderer_state_db(db, state_key, state)
+            return
+        state["current_index"] = next_index
+        state["position_seconds"] = 0
+        state["is_playing"] = True
+        state["transport_state"] = "PLAYING"
+        await update_renderer_state_db(db, state_key, state)
+        track = queue[next_index]
+        renderer_id = self.registry.state_key_to_renderer_id(state_key)
+        await self._play_remote(renderer_id, state_key, track, track.get("user_id"), None)
 
     @staticmethod
     def _current_track(state: dict[str, Any]) -> dict[str, Any] | None:

--- a/app/services/renderer/orchestrator.py
+++ b/app/services/renderer/orchestrator.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import time
+from typing import Any
+
+import asyncpg
+from fastapi import HTTPException, Request
+
+from app.services.player.globals import last_track_start_time, monitor_start_times, playback_monitors
+from app.services.player.history import reset_history_tracker
+from app.services.player.monitor import (
+    _clear_monitor_starting,
+    _mark_monitor_starting,
+    start_monitor_task,
+)
+from app.services.player.state import (
+    enrich_track_metadata,
+    get_renderer_state_db,
+    track_path_exists,
+    update_renderer_state_db,
+)
+from app.services.renderer.contracts import PlaybackContext, is_local_renderer
+from app.services.renderer.registry import RendererRegistry, get_renderer_registry
+from app.services.renderer.token_policy import stream_token_ttl_seconds
+
+
+class RendererOrchestrator:
+    def __init__(self, registry: RendererRegistry | None = None) -> None:
+        self.registry = registry or get_renderer_registry()
+
+    async def get_active(self, db: asyncpg.Connection, client_id: str) -> tuple[str, str]:
+        return await self.registry.get_active(db, client_id)
+
+    async def set_active(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        renderer_id_or_udn: str,
+    ) -> tuple[str, str]:
+        return await self.registry.set_active(db, client_id, renderer_id_or_udn)
+
+    async def list_renderers(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        refresh: bool = False,
+    ) -> list[dict[str, Any]]:
+        devices = await self.registry.discover_all(refresh=refresh) if refresh else await self.registry.list_all()
+        await self.registry.persist_all(db, devices)
+        return [self.registry.local_renderer(client_id), *[d.as_api_dict() for d in devices]]
+
+    async def add_manual(self, address: str) -> bool:
+        backend = self.registry.backends.get("upnp")
+        if not backend:
+            return False
+        return await backend.add_manual(address) is not None
+
+    async def set_queue(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        queue: list[dict[str, Any]],
+        start_index: int,
+        user_id: int | None,
+        request: Request,
+    ) -> None:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["queue"] = queue
+        state["current_index"] = max(0, min(start_index, len(queue) - 1 if queue else 0))
+        state["position_seconds"] = 0
+        state["is_playing"] = True
+        state["transport_state"] = "PLAYING"
+        await update_renderer_state_db(db, state_key, state)
+        reset_history_tracker(state_key if not is_local_renderer(state_key) else client_id)
+
+        if not is_local_renderer(renderer_id) and state["queue"]:
+            playable_idx = await self._first_playable_index(db, state, state["current_index"])
+            if playable_idx is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail="No playable tracks found on disk for this queue.",
+                )
+            state["current_index"] = playable_idx
+            await update_renderer_state_db(db, state_key, state)
+            track = state["queue"][state["current_index"]]
+            asyncio.create_task(
+                self._play_remote_background(renderer_id, state_key, track, user_id, request)
+            )
+
+    async def play_track(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        track: dict[str, Any],
+        user_id: int | None,
+        request: Request,
+    ) -> dict[str, Any]:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        if is_local_renderer(renderer_id):
+            state = await get_renderer_state_db(db, state_key)
+            current_index = self._replace_or_singleton_queue(state, track)
+            state["current_index"] = current_index
+            state["position_seconds"] = 0
+            state["is_playing"] = True
+            state["transport_state"] = "PLAYING"
+            await update_renderer_state_db(db, state_key, state)
+            return {"status": "local_playback", "message": "Handle playback in browser"}
+
+        state = await get_renderer_state_db(db, state_key)
+        current_track = self._current_track(state)
+        if current_track and current_track.get("id") == track["id"] and state.get("is_playing"):
+            if state_key not in playback_monitors or playback_monitors[state_key].done():
+                start_monitor_task(state_key)
+                last_track_start_time[state_key] = time.time()
+            return {"status": "already_playing", "renderer": state_key}
+
+        if current_track and current_track.get("id") == track["id"] and not state.get("is_playing"):
+            await self.resume(db, client_id)
+            return {"status": "resumed", "renderer": state_key}
+
+        current_index = self._replace_or_singleton_queue(state, track)
+        state["current_index"] = current_index
+        state["position_seconds"] = 0
+        state["is_playing"] = True
+        state["transport_state"] = "PLAYING"
+        await update_renderer_state_db(db, state_key, state)
+        reset_history_tracker(state_key)
+        await self._cancel_monitor(state_key)
+        await self._play_remote(renderer_id, state_key, track, user_id, request)
+        return {"status": "streaming_started", "renderer": state_key}
+
+    async def pause(self, db: asyncpg.Connection, client_id: str) -> None:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["is_playing"] = False
+        await update_renderer_state_db(db, state_key, state)
+        if not is_local_renderer(renderer_id):
+            await self.registry.get_backend(renderer_id).pause(renderer_id)
+            if state_key in playback_monitors:
+                playback_monitors[state_key].cancel()
+                del playback_monitors[state_key]
+
+    async def resume(self, db: asyncpg.Connection, client_id: str) -> None:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["is_playing"] = True
+        await update_renderer_state_db(db, state_key, state)
+        if not is_local_renderer(renderer_id):
+            await self.registry.get_backend(renderer_id).resume(renderer_id)
+            if state_key not in playback_monitors or playback_monitors[state_key].done():
+                start_monitor_task(state_key)
+                monitor_start_times[state_key] = time.time()
+
+    async def stop_or_clear(self, db: asyncpg.Connection, client_id: str) -> tuple[dict[str, Any], str]:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["queue"] = []
+        state["current_index"] = -1
+        state["position_seconds"] = 0
+        state["is_playing"] = False
+        state["transport_state"] = "STOPPED"
+        await update_renderer_state_db(db, state_key, state)
+        reset_history_tracker(client_id if is_local_renderer(state_key) else state_key)
+        if not is_local_renderer(renderer_id):
+            try:
+                await self.registry.get_backend(renderer_id).stop_playback(renderer_id)
+            except Exception:
+                await self.registry.get_backend(renderer_id).pause(renderer_id)
+            await self._cancel_monitor(state_key, remove=True)
+        return state, state_key
+
+    async def seek(self, db: asyncpg.Connection, client_id: str, seconds: float) -> str:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["position_seconds"] = seconds
+        await update_renderer_state_db(db, state_key, state)
+        if not is_local_renderer(renderer_id):
+            await self.registry.get_backend(renderer_id).seek(renderer_id, seconds)
+            return "remote"
+        return "local"
+
+    async def set_volume(self, db: asyncpg.Connection, client_id: str, percent: int) -> None:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["volume"] = percent
+        await update_renderer_state_db(db, state_key, state)
+        if not is_local_renderer(renderer_id):
+            await self.registry.get_backend(renderer_id).set_volume(renderer_id, percent)
+
+    async def skip_to_index(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        index: int,
+        request: Request | None = None,
+    ) -> tuple[dict[str, Any], str]:
+        renderer_id, state_key = await self.get_active(db, client_id)
+        state = await get_renderer_state_db(db, state_key)
+        state["current_index"] = index
+        state["position_seconds"] = 0
+        state["is_playing"] = True
+        state["transport_state"] = "PLAYING"
+        await update_renderer_state_db(db, state_key, state)
+        reset_history_tracker(client_id if is_local_renderer(state_key) else state_key)
+
+        if not is_local_renderer(renderer_id):
+            queue = state.get("queue") or []
+            if queue and 0 <= state["current_index"] < len(queue):
+                playable_idx = await self._first_playable_index(db, state, state["current_index"])
+                if playable_idx is None:
+                    raise HTTPException(status_code=404, detail="Selected track is missing on disk.")
+                state["current_index"] = playable_idx
+                await update_renderer_state_db(db, state_key, state)
+                await self._cancel_monitor(state_key)
+                track = state["queue"][state["current_index"]]
+                await self._play_remote(renderer_id, state_key, track, track.get("user_id"), request)
+        return state, state_key
+
+    async def _play_remote_background(
+        self,
+        renderer_id: str,
+        state_key: str,
+        track: dict[str, Any],
+        user_id: int | None,
+        request: Request,
+    ) -> None:
+        _mark_monitor_starting(state_key)
+        try:
+            await self._cancel_monitor(state_key)
+            await self._play_remote(renderer_id, state_key, track, user_id, request)
+        finally:
+            _clear_monitor_starting(state_key)
+
+    async def _play_remote(
+        self,
+        renderer_id: str,
+        state_key: str,
+        track: dict[str, Any],
+        user_id: int | None,
+        request: Request | None,
+    ) -> None:
+        _mark_monitor_starting(state_key)
+        try:
+            context = PlaybackContext(
+                base_url=self._base_url(request),
+                user_id=user_id or track.get("user_id"),
+                token_ttl_seconds=stream_token_ttl_seconds(
+                    renderer_id.split(":", 1)[0] if ":" in renderer_id else None,
+                    track.get("duration_seconds"),
+                ),
+            )
+            await self.registry.get_backend(renderer_id).play_track(renderer_id, track, context)
+            start_monitor_task(state_key)
+            last_track_start_time[state_key] = time.time()
+        finally:
+            _clear_monitor_starting(state_key)
+
+    async def _cancel_monitor(self, state_key: str, remove: bool = False) -> None:
+        if state_key in playback_monitors:
+            playback_monitors[state_key].cancel()
+            try:
+                await asyncio.wait([playback_monitors[state_key]], timeout=1)
+            except Exception:
+                pass
+            if remove:
+                playback_monitors.pop(state_key, None)
+
+    async def _first_playable_index(
+        self,
+        db: asyncpg.Connection,
+        state: dict[str, Any],
+        start_index: int,
+    ) -> int | None:
+        for idx in range(start_index, len(state.get("queue") or [])):
+            candidate = await enrich_track_metadata(state["queue"][idx], db)
+            if track_path_exists(candidate):
+                state["queue"][idx] = candidate
+                return idx
+        return None
+
+    def _base_url(self, request: Request | None) -> str:
+        upnp_backend = self.registry.backends.get("upnp")
+        manager = getattr(upnp_backend, "manager", None)
+        local_ip = getattr(manager, "local_ip", "127.0.0.1")
+        env_port = os.environ.get("HOST_PORT")
+        port = env_port if env_port else ((request.url.port if request else None) or 8111)
+        return f"http://{local_ip}:{port}"
+
+    @staticmethod
+    def _current_track(state: dict[str, Any]) -> dict[str, Any] | None:
+        queue = state.get("queue") or []
+        idx = state.get("current_index")
+        if idx is not None and 0 <= idx < len(queue):
+            return queue[idx]
+        return None
+
+    @staticmethod
+    def _replace_or_singleton_queue(state: dict[str, Any], track: dict[str, Any]) -> int:
+        existing_queue = state.get("queue") or []
+        try:
+            current_index = next(i for i, item in enumerate(existing_queue) if item.get("id") == track["id"])
+            existing_queue[current_index] = track
+        except StopIteration:
+            existing_queue = [track]
+            current_index = 0
+        state["queue"] = existing_queue
+        return current_index
+
+
+_orchestrator: RendererOrchestrator | None = None
+
+
+def get_renderer_orchestrator() -> RendererOrchestrator:
+    global _orchestrator
+    if _orchestrator is None:
+        _orchestrator = RendererOrchestrator()
+    return _orchestrator

--- a/app/services/renderer/persistence.py
+++ b/app/services/renderer/persistence.py
@@ -18,9 +18,10 @@ async def register_or_update_renderer(
         INSERT INTO renderer (
             renderer_id, kind, native_id, udn, friendly_name, ip, manufacturer,
             model_name, cast_type, last_discovered_by, available,
-            enabled_by_default, supported_mime_types, last_seen_at
+            enabled_by_default, supported_mime_types, icon_url, icon_mime,
+            icon_width, icon_height, last_seen_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
         ON CONFLICT (renderer_id) DO UPDATE SET
             kind = EXCLUDED.kind,
             native_id = EXCLUDED.native_id,
@@ -34,6 +35,10 @@ async def register_or_update_renderer(
             available = EXCLUDED.available,
             enabled_by_default = EXCLUDED.enabled_by_default,
             supported_mime_types = EXCLUDED.supported_mime_types,
+            icon_url = EXCLUDED.icon_url,
+            icon_mime = EXCLUDED.icon_mime,
+            icon_width = EXCLUDED.icon_width,
+            icon_height = EXCLUDED.icon_height,
             last_seen_at = NOW()
         """,
         device.renderer_id,
@@ -49,6 +54,10 @@ async def register_or_update_renderer(
         device.available,
         device.enabled_by_default,
         ",".join(sorted(device.capabilities.supported_mime_types)),
+        device.icon_url,
+        device.icon_mime,
+        device.icon_width,
+        device.icon_height,
     )
 
 
@@ -105,6 +114,10 @@ def renderer_row_to_api(row: asyncpg.Record | dict[str, Any]) -> dict[str, Any]:
         "manufacturer": _row_get(row, "manufacturer"),
         "model_name": _row_get(row, "model_name"),
         "cast_type": _row_get(row, "cast_type"),
+        "icon_url": _row_get(row, "icon_url"),
+        "icon_mime": _row_get(row, "icon_mime"),
+        "icon_width": _row_get(row, "icon_width"),
+        "icon_height": _row_get(row, "icon_height"),
         "discovered_by": _row_get(row, "last_discovered_by", "server"),
         "available": _row_get(row, "available", True),
         "enabled_by_default": _row_get(row, "enabled_by_default", True),

--- a/app/services/renderer/persistence.py
+++ b/app/services/renderer/persistence.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import asyncpg
+
+from app.services.renderer.contracts import RendererDevice
+
+
+async def register_or_update_renderer(
+    db: asyncpg.Connection,
+    device: RendererDevice,
+) -> None:
+    """Persist a normalized renderer device."""
+    await db.execute(
+        """
+        INSERT INTO renderer (
+            renderer_id, kind, native_id, udn, friendly_name, ip, manufacturer,
+            model_name, cast_type, last_discovered_by, available,
+            enabled_by_default, supported_mime_types, last_seen_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+        ON CONFLICT (renderer_id) DO UPDATE SET
+            kind = EXCLUDED.kind,
+            native_id = EXCLUDED.native_id,
+            udn = EXCLUDED.udn,
+            friendly_name = EXCLUDED.friendly_name,
+            ip = EXCLUDED.ip,
+            manufacturer = EXCLUDED.manufacturer,
+            model_name = EXCLUDED.model_name,
+            cast_type = EXCLUDED.cast_type,
+            last_discovered_by = EXCLUDED.last_discovered_by,
+            available = EXCLUDED.available,
+            enabled_by_default = EXCLUDED.enabled_by_default,
+            supported_mime_types = EXCLUDED.supported_mime_types,
+            last_seen_at = NOW()
+        """,
+        device.renderer_id,
+        device.kind,
+        device.native_id,
+        device.udn or device.native_id,
+        device.name,
+        device.ip,
+        device.manufacturer,
+        device.model_name,
+        device.cast_type,
+        device.discovered_by,
+        device.available,
+        device.enabled_by_default,
+        ",".join(sorted(device.capabilities.supported_mime_types)),
+    )
+
+
+async def mark_renderer_unavailable(db: asyncpg.Connection, renderer_id: str) -> None:
+    await db.execute(
+        "UPDATE renderer SET available = FALSE WHERE renderer_id = $1",
+        renderer_id,
+    )
+
+
+def _row_get(row: asyncpg.Record | dict[str, Any], key: str, default: Any = None) -> Any:
+    try:
+        value = row[key]
+    except KeyError:
+        return default
+    return default if value is None else value
+
+
+def renderer_row_to_api(row: asyncpg.Record | dict[str, Any]) -> dict[str, Any]:
+    supported_mime_types = _row_get(row, "supported_mime_types", "")
+    capabilities = {
+        "can_play": True,
+        "can_pause": True,
+        "can_stop": True,
+        "can_seek": True,
+        "can_set_volume": True,
+        "can_mute": False,
+        "can_next_previous": False,
+        "can_enqueue": False,
+        "can_group": False,
+        "can_power": False,
+        "reports_progress": True,
+        "supports_events": bool(_row_get(row, "supports_events", False)),
+        "requires_flow_mode": False,
+        "supported_mime_types": [
+            item for item in supported_mime_types.split(",") if item
+        ],
+    }
+    metadata = _row_get(row, "renderer_metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    metadata = metadata or {}
+    return {
+        "renderer_id": _row_get(row, "renderer_id") or f"upnp:{row['udn']}",
+        "kind": _row_get(row, "kind", "upnp"),
+        "native_id": _row_get(row, "native_id") or row["udn"],
+        "udn": row["udn"],
+        "name": _row_get(row, "friendly_name") or _row_get(row, "name") or "Renderer",
+        "type": _row_get(row, "kind", "upnp"),
+        "ip": _row_get(row, "ip"),
+        "manufacturer": _row_get(row, "manufacturer"),
+        "model_name": _row_get(row, "model_name"),
+        "cast_type": _row_get(row, "cast_type"),
+        "discovered_by": _row_get(row, "last_discovered_by", "server"),
+        "available": _row_get(row, "available", True),
+        "enabled_by_default": _row_get(row, "enabled_by_default", True),
+        "is_group": bool(metadata.get("is_group", False)),
+        "group_members": metadata.get("group_members", []),
+        "capabilities": capabilities,
+    }

--- a/app/services/renderer/registry.py
+++ b/app/services/renderer/registry.py
@@ -13,6 +13,10 @@ from app.services.renderer.contracts import (
 )
 from app.services.renderer.persistence import register_or_update_renderer
 from app.services.renderer.upnp_backend import UpnpRendererBackend
+try:
+    from app.services.renderer.cast_backend import CastRendererBackend
+except Exception:
+    CastRendererBackend = None
 
 
 class RendererRegistry:
@@ -164,4 +168,6 @@ def get_renderer_registry() -> RendererRegistry:
     if _registry is None:
         _registry = RendererRegistry()
         _registry.register_backend(UpnpRendererBackend())
+        if CastRendererBackend is not None:
+            _registry.register_backend(CastRendererBackend())
     return _registry

--- a/app/services/renderer/registry.py
+++ b/app/services/renderer/registry.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from app.services.renderer.contracts import (
+    RendererBackend,
+    RendererDevice,
+    is_local_renderer,
+    make_renderer_id,
+    split_renderer_id,
+)
+from app.services.renderer.persistence import register_or_update_renderer
+from app.services.renderer.upnp_backend import UpnpRendererBackend
+
+
+class RendererRegistry:
+    def __init__(self) -> None:
+        self.backends: dict[str, RendererBackend] = {}
+
+    def register_backend(self, backend: RendererBackend) -> None:
+        self.backends[backend.kind] = backend
+
+    async def start_all(self) -> None:
+        for backend in self.backends.values():
+            await backend.start()
+
+    async def stop_all(self) -> None:
+        for backend in self.backends.values():
+            await backend.stop()
+
+    def normalize_renderer_id(self, renderer_id: str) -> str:
+        if is_local_renderer(renderer_id):
+            return renderer_id
+        kind, native_id = split_renderer_id(renderer_id)
+        return make_renderer_id(kind, native_id)
+
+    def legacy_or_renderer_id_to_state_key(self, renderer_id: str) -> str:
+        if is_local_renderer(renderer_id):
+            return renderer_id
+        kind, native_id = split_renderer_id(renderer_id)
+        if kind == "upnp":
+            return native_id
+        return make_renderer_id(kind, native_id)
+
+    def state_key_to_renderer_id(self, state_key: str) -> str:
+        if is_local_renderer(state_key):
+            return state_key
+        kind, native_id = split_renderer_id(state_key)
+        if state_key.startswith(f"{kind}:") and native_id != state_key:
+            return state_key
+        return make_renderer_id("upnp", state_key)
+
+    def get_backend(self, renderer_id: str) -> RendererBackend:
+        if is_local_renderer(renderer_id):
+            raise ValueError("Local renderer has no backend")
+        kind, _ = split_renderer_id(renderer_id)
+        backend = self.backends.get(kind)
+        if not backend:
+            raise ValueError(f"No renderer backend registered for {kind}")
+        return backend
+
+    async def discover_all(self, refresh: bool = False) -> list[RendererDevice]:
+        devices: list[RendererDevice] = []
+        for backend in self.backends.values():
+            devices.extend(await backend.discover(refresh=refresh))
+        return devices
+
+    async def list_all(self) -> list[RendererDevice]:
+        devices: list[RendererDevice] = []
+        for backend in self.backends.values():
+            devices.extend(await backend.list_devices())
+        return devices
+
+    async def persist_all(self, db: asyncpg.Connection, devices: list[RendererDevice]) -> None:
+        for device in devices:
+            await register_or_update_renderer(db, device)
+
+    async def set_active(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+        renderer_id_or_udn: str,
+    ) -> tuple[str, str]:
+        renderer_id = self.normalize_renderer_id(renderer_id_or_udn)
+        state_key = self.legacy_or_renderer_id_to_state_key(renderer_id)
+        await db.execute(
+            """
+            INSERT INTO client_session (
+                client_id, active_renderer_udn, active_renderer_id, last_seen_at
+            )
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT(client_id) DO UPDATE SET
+                active_renderer_udn = excluded.active_renderer_udn,
+                active_renderer_id = excluded.active_renderer_id,
+                last_seen_at = NOW()
+            """,
+            client_id,
+            state_key,
+            renderer_id,
+        )
+        return renderer_id, state_key
+
+    async def get_active(
+        self,
+        db: asyncpg.Connection,
+        client_id: str,
+    ) -> tuple[str, str]:
+        row = await db.fetchrow(
+            """
+            SELECT active_renderer_id, active_renderer_udn
+            FROM client_session
+            WHERE client_id = $1
+            """,
+            client_id,
+        )
+        if row:
+            state_key = row["active_renderer_udn"] or row["active_renderer_id"]
+            renderer_id = row["active_renderer_id"] or self.state_key_to_renderer_id(state_key)
+            return renderer_id, state_key
+
+        state_key = f"local:{client_id}"
+        renderer_id = state_key
+        await db.execute(
+            """
+            INSERT INTO client_session (
+                client_id, active_renderer_udn, active_renderer_id, last_seen_at
+            )
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT (client_id) DO NOTHING
+            """,
+            client_id,
+            state_key,
+            renderer_id,
+        )
+        return renderer_id, state_key
+
+    def local_renderer(self, client_id: str) -> dict[str, Any]:
+        renderer_id = f"local:{client_id}"
+        return {
+            "udn": renderer_id,
+            "renderer_id": renderer_id,
+            "kind": "local",
+            "native_id": client_id,
+            "name": "This Device (Web Browser)",
+            "type": "local",
+            "capabilities": {
+                "can_play": True,
+                "can_pause": True,
+                "can_stop": True,
+                "can_seek": True,
+                "can_set_volume": True,
+                "reports_progress": True,
+            },
+        }
+
+
+_registry: RendererRegistry | None = None
+
+
+def get_renderer_registry() -> RendererRegistry:
+    global _registry
+    if _registry is None:
+        _registry = RendererRegistry()
+        _registry.register_backend(UpnpRendererBackend())
+    return _registry

--- a/app/services/renderer/token_policy.py
+++ b/app/services/renderer/token_policy.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+
+def stream_token_ttl_seconds(
+    renderer_kind: str | None,
+    duration_seconds: float | int | None = None,
+) -> int | None:
+    if renderer_kind != "cast":
+        return None
+
+    max_ttl = int(os.getenv("CAST_STREAM_TOKEN_TTL_SECONDS", "86400"))
+    if duration_seconds:
+        return min(max_ttl, max(1800, int(float(duration_seconds) * 2)))
+    return max_ttl

--- a/app/services/renderer/upnp_backend.py
+++ b/app/services/renderer/upnp_backend.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.renderer.contracts import (
+    PlaybackContext,
+    RendererBackend,
+    RendererCapabilities,
+    RendererDevice,
+    RendererStatus,
+    make_renderer_id,
+    split_renderer_id,
+)
+from app.upnp import UPnPManager
+
+
+class UpnpRendererBackend(RendererBackend):
+    kind = "upnp"
+
+    def __init__(self, manager: UPnPManager | None = None) -> None:
+        self.manager = manager or UPnPManager.get_instance()
+
+    async def start(self) -> None:
+        self.manager.start_background_scan()
+
+    async def stop(self) -> None:
+        await self.manager.stop_background_scan()
+
+    async def discover(self, refresh: bool = False) -> list[RendererDevice]:
+        if refresh:
+            await self.manager.discover()
+        return await self.list_devices()
+
+    async def add_manual(self, address: str) -> RendererDevice | None:
+        found = await self.manager.add_device_by_ip(address)
+        if not found:
+            return None
+        for device in await self.list_devices():
+            if device.ip == address:
+                return device
+        return None
+
+    async def list_devices(self) -> list[RendererDevice]:
+        renderers = await self.manager.get_renderers()
+        return [self._device_from_renderer(renderer) for renderer in renderers]
+
+    async def unload_device(self, renderer_id: str) -> None:
+        _, udn = split_renderer_id(renderer_id)
+        self.manager.renderers.pop(udn, None)
+        self.manager.dmr_devices.pop(udn, None)
+
+    async def play_track(
+        self,
+        renderer_id: str,
+        track: dict[str, Any],
+        context: PlaybackContext,
+    ) -> RendererStatus:
+        _, udn = split_renderer_id(renderer_id)
+        await self.manager.set_renderer(udn)
+        self.manager.base_url = context.base_url
+        await self.manager.play_track(
+            int(track["id"]),
+            track.get("path"),
+            track,
+            username=context.username,
+        )
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING")
+
+    async def pause(self, renderer_id: str) -> RendererStatus:
+        await self._set_active(renderer_id)
+        await self.manager.pause()
+        return RendererStatus(renderer_id=renderer_id, state="PAUSED")
+
+    async def resume(self, renderer_id: str) -> RendererStatus:
+        await self._set_active(renderer_id)
+        await self.manager.resume()
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING")
+
+    async def stop_playback(self, renderer_id: str) -> RendererStatus:
+        await self._set_active(renderer_id)
+        control = getattr(self.manager, "control", None)
+        if control and hasattr(control, "stop"):
+            await control.stop()
+        else:
+            await self.manager.pause()
+        return RendererStatus(renderer_id=renderer_id, state="STOPPED")
+
+    async def seek(self, renderer_id: str, seconds: float) -> RendererStatus:
+        await self._set_active(renderer_id)
+        await self.manager.seek(seconds)
+        return RendererStatus(renderer_id=renderer_id, state="PLAYING", position_seconds=seconds)
+
+    async def set_volume(self, renderer_id: str, percent: int) -> RendererStatus:
+        await self._set_active(renderer_id)
+        await self.manager.set_volume(percent)
+        return RendererStatus(renderer_id=renderer_id, state="UNKNOWN", volume_percent=percent)
+
+    async def mute(self, renderer_id: str, muted: bool) -> RendererStatus:
+        raise NotImplementedError("UPnP mute is not implemented")
+
+    async def get_status(self, renderer_id: str) -> RendererStatus:
+        _, udn = split_renderer_id(renderer_id)
+        position, duration = await self.manager.get_position(udn)
+        transport = await self.manager.get_transport_info(udn)
+        return RendererStatus(
+            renderer_id=renderer_id,
+            state=self.normalize_transport_state(transport),
+            position_seconds=float(position or 0),
+            duration_seconds=float(duration) if duration is not None else None,
+        )
+
+    async def _set_active(self, renderer_id: str) -> str:
+        _, udn = split_renderer_id(renderer_id)
+        await self.manager.set_renderer(udn)
+        return udn
+
+    def _device_from_renderer(self, renderer: dict[str, Any]) -> RendererDevice:
+        udn = renderer.get("udn") or renderer.get("native_id")
+        supported_mimes = {
+            item
+            for item in (renderer.get("supported_mime_types") or "").split(",")
+            if item
+        }
+        return RendererDevice(
+            renderer_id=make_renderer_id(self.kind, udn),
+            kind=self.kind,
+            native_id=udn,
+            udn=udn,
+            name=renderer.get("name")
+            or renderer.get("friendly_name")
+            or renderer.get("model_name")
+            or "UPnP Renderer",
+            ip=renderer.get("ip"),
+            manufacturer=renderer.get("manufacturer"),
+            model_name=renderer.get("model_name"),
+            capabilities=RendererCapabilities(
+                supported_mime_types=supported_mimes,
+                supports_events=bool(renderer.get("supports_events", False)),
+            ),
+        )
+
+    @staticmethod
+    def normalize_transport_state(transport_state: str | None) -> str:
+        if transport_state in {"PLAYING", "TRANSITIONING"}:
+            return "PLAYING"
+        if transport_state in {"PAUSED_PLAYBACK", "PAUSED_RECORDING", "PAUSED"}:
+            return "PAUSED"
+        if transport_state in {"STOPPED", "NO_MEDIA_PRESENT", "IDLE"}:
+            return "IDLE"
+        return "UNKNOWN"

--- a/app/services/renderer/upnp_backend.py
+++ b/app/services/renderer/upnp_backend.py
@@ -133,6 +133,12 @@ class UpnpRendererBackend(RendererBackend):
             ip=renderer.get("ip"),
             manufacturer=renderer.get("manufacturer"),
             model_name=renderer.get("model_name"),
+            model_number=renderer.get("model_number"),
+            device_type=renderer.get("device_type"),
+            icon_url=renderer.get("icon_url"),
+            icon_mime=renderer.get("icon_mime"),
+            icon_width=renderer.get("icon_width"),
+            icon_height=renderer.get("icon_height"),
             capabilities=RendererCapabilities(
                 supported_mime_types=supported_mimes,
                 supports_events=bool(renderer.get("supports_events", False)),

--- a/app/upnp.py
+++ b/app/upnp.py
@@ -164,7 +164,7 @@ class UPnPManager:
         return await self.discovery.verify_device(r)
 
     async def save_renderer(self, r: Dict[str, Any]):
-        # This one writes to DB, kept here or moved? 
+        # This one writes to DB, kept here or moved?
         # It was on Manager. Let's keep it here or move to a persistence module.
         # Discovery uses it. Let's keep it here to allow Discovery to call back.
         from app.db import get_db
@@ -172,12 +172,15 @@ class UPnPManager:
             await db.execute(
                 """
                 INSERT INTO renderer 
-                (udn, friendly_name, location_url, ip, control_url, rendering_control_url, 
+                (udn, kind, native_id, renderer_id, friendly_name, location_url, ip, control_url, rendering_control_url,
                  device_type, manufacturer, model_name, model_number, serial_number, 
                  firmware_version, supports_events, supports_gapless, supported_mime_types,
-                 icon_url, icon_mime, icon_width, icon_height, last_seen_at)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, NOW())
+                 icon_url, icon_mime, icon_width, icon_height, last_discovered_by, available, enabled_by_default, last_seen_at)
+                VALUES ($1, 'upnp', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, 'server', TRUE, TRUE, NOW())
                 ON CONFLICT (udn) DO UPDATE SET
+                    kind = 'upnp',
+                    native_id = EXCLUDED.native_id,
+                    renderer_id = EXCLUDED.renderer_id,
                     friendly_name = EXCLUDED.friendly_name,
                     location_url = EXCLUDED.location_url,
                     ip = EXCLUDED.ip,
@@ -196,9 +199,13 @@ class UPnPManager:
                     icon_mime = EXCLUDED.icon_mime,
                     icon_width = EXCLUDED.icon_width,
                     icon_height = EXCLUDED.icon_height,
+                    last_discovered_by = EXCLUDED.last_discovered_by,
+                    available = TRUE,
+                    enabled_by_default = COALESCE(renderer.enabled_by_default, TRUE),
                     last_seen_at = NOW()
             """,
                 r["udn"],
+                f"upnp:{r['udn']}",
                 r.get("friendly_name"),
                 r.get("location"),
                 r.get("ip"),

--- a/dev.sh
+++ b/dev.sh
@@ -49,11 +49,11 @@ else
   echo "✨ Dependencies unchanged, skipping build."
 fi
 
-# Stop existing containers before clearing generated frontend state.
-docker compose down
+# Stop the same compose stack we start below, including the dev-only web service.
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans
 
-# Clear generated frontend caches so route graph changes cannot leave
-# stale .svelte-kit / Vite artifacts behind across dev restarts.
+# Clear host-side generated frontend caches. The web service also clears its
+# Docker-owned .svelte-kit/.vite volumes at container startup.
 echo "🧽 Clearing frontend dev caches..."
 rm -rf web/.svelte-kit web/.vite
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
       # Keep generated dev artifacts inside Docker-owned volumes
       - jamarr_web_svelte_kit:/app/web/.svelte-kit
       - jamarr_web_vite_cache:/app/web/.vite
-    entrypoint: /bin/sh -c "npm install && npx svelte-kit sync && npm run dev:host -- --force"
+    entrypoint: /bin/sh -c "find .svelte-kit .vite -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true; npm install && npx svelte-kit sync && npm run dev:host -- --force"
     environment:
       - VITE_API_URL=${VITE_API_URL:-http://127.0.0.1:8111}
     restart: unless-stopped

--- a/docs/chromecast-phase0-baseline.md
+++ b/docs/chromecast-phase0-baseline.md
@@ -1,0 +1,62 @@
+# Chromecast Phase 0 Baseline
+
+Phase 0 records current playback behavior before the renderer backend refactor.
+It should not change production code.
+
+Status: completed on 2026-04-30 with the targeted Phase 0 gate passing.
+
+## Current Control Paths
+
+- Local web/mobile playback stores queue and progress in `renderer_state` under
+  `local:<client_id>`. The client plays audio and reports progress.
+- Server UPnP playback stores active renderer in
+  `client_session.active_renderer_udn`. Player API endpoints call the process
+  singleton `UPnPManager` directly.
+- Android device-UPnP keeps server state pinned to `local:<client_id>`, then the
+  phone controls the UPnP renderer and reports queue/progress back to the server.
+
+## Current Ownership
+
+- `client_session.active_renderer_udn`: active local/remote renderer per client.
+- `renderer_state.renderer_udn`: queue, current index, progress, playing state,
+  transport state, and volume.
+- `app/api/player.py`: API orchestration and direct UPnP command routing.
+- `app/services/player/monitor.py`: UPnP polling, progress/state updates,
+  history logging, and auto-advance detection.
+- `app/services/player/queue.py`: current auto-advance helper, hardwired to
+  `UPnPManager`.
+- `app/services/upnp/device.py`: UPnP stream URL, DIDL metadata, MIME selection,
+  and device commands.
+
+## Stream Tokens
+
+- `/api/stream-url/{track_id}` requires auth and returns
+  `/api/stream/{track_id}?token=...`.
+- Stream tokens are stateless JWTs.
+- Current default stream token TTL is 300 seconds.
+- Tokens are bound to `track_id`; `verify_stream_token()` rejects tokens for the
+  wrong track.
+
+## Phase 0 Test Coverage
+
+- `tests/helpers/fake_renderers.py`
+  - Reusable fake UPnP manager command recorder.
+  - Reusable fake status helpers for future backend/orchestrator tests.
+- `tests/api/test_player_phase0_api.py`
+  - Characterizes current remote UPnP transport command routing.
+  - Characterizes current remote `/api/player/play` behavior and state writes.
+- `tests/unit/test_player_phase0_unit.py`
+  - Characterizes current `play_next_track_internal()` behavior.
+  - Covers queue auto-advance and end-of-queue state.
+- `tests/auth/test_stream_token_phase0.py`
+  - Characterizes default stream token TTL and claims.
+
+## Phase 0 Gate
+
+Run:
+
+```bash
+./test.sh tests/api/test_player.py tests/api/test_stream.py tests/api/test_player_phase0_api.py tests/unit/test_player_phase0_unit.py tests/auth/test_stream_token_phase0.py
+```
+
+These tests should pass before starting Phase 1.

--- a/migrations/029_renderer_backend.sql
+++ b/migrations/029_renderer_backend.sql
@@ -1,0 +1,62 @@
+-- Migration 029: Add protocol-neutral renderer backend fields.
+
+ALTER TABLE renderer
+    ADD COLUMN IF NOT EXISTS kind TEXT DEFAULT 'upnp',
+    ADD COLUMN IF NOT EXISTS native_id TEXT,
+    ADD COLUMN IF NOT EXISTS renderer_id TEXT,
+    ADD COLUMN IF NOT EXISTS cast_uuid TEXT,
+    ADD COLUMN IF NOT EXISTS cast_type TEXT,
+    ADD COLUMN IF NOT EXISTS last_discovered_by TEXT DEFAULT 'server',
+    ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS enabled_by_default BOOLEAN DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS renderer_metadata JSONB DEFAULT '{}'::jsonb;
+
+UPDATE renderer
+SET
+    kind = COALESCE(kind, 'upnp'),
+    native_id = COALESCE(native_id, udn),
+    renderer_id = COALESCE(renderer_id, 'upnp:' || udn),
+    last_discovered_by = COALESCE(last_discovered_by, 'server'),
+    available = COALESCE(available, TRUE),
+    enabled_by_default = COALESCE(enabled_by_default, TRUE),
+    renderer_metadata = COALESCE(renderer_metadata, '{}'::jsonb)
+WHERE udn IS NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_attribute a
+          ON a.attrelid = t.oid
+         AND a.attnum = ANY(c.conkey)
+        WHERE t.relname = 'renderer'
+          AND c.contype = 'u'
+          AND a.attname = 'renderer_id'
+    ) THEN
+        ALTER TABLE renderer
+            ADD CONSTRAINT renderer_renderer_id_unique UNIQUE (renderer_id);
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_renderer_renderer_id
+    ON renderer(renderer_id)
+    WHERE renderer_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_renderer_cast_uuid
+    ON renderer(cast_uuid)
+    WHERE cast_uuid IS NOT NULL;
+
+ALTER TABLE client_session
+    ADD COLUMN IF NOT EXISTS active_renderer_id TEXT;
+
+UPDATE client_session
+SET active_renderer_id = CASE
+    WHEN active_renderer_udn IS NULL THEN NULL
+    WHEN active_renderer_udn LIKE 'local:%' THEN active_renderer_udn
+    WHEN active_renderer_udn LIKE 'upnp:%' THEN active_renderer_udn
+    WHEN active_renderer_udn LIKE 'cast:%' THEN active_renderer_udn
+    ELSE 'upnp:' || active_renderer_udn
+END
+WHERE active_renderer_id IS NULL;

--- a/plan-chromecast.md
+++ b/plan-chromecast.md
@@ -613,6 +613,34 @@ app/services/player/monitor.py (modify)
 
 Server discovers and controls Cast devices on same LAN. Useful for home-server deployments (Docker on NAS, Pi, etc.).
 
+### Phase 2 implementation status
+
+Implemented in this branch:
+
+- Added `pychromecast` and `zeroconf` dependencies
+- Added `CastRendererBackend` behind the Phase 1 `RendererBackend` contract
+- Cast discovery converts pychromecast devices into canonical `cast:<uuid>`
+  renderers and persists through shared renderer persistence
+- Manual Cast host/IP discovery is supported through the backend
+- Cast play/pause/resume/stop/seek/volume/mute/status commands route through
+  pychromecast
+- Cast playback uses the Default Media Receiver and Cast-safe stream token TTL
+  policy from the orchestrator
+- Cast media status callbacks dispatch back onto the asyncio loop and update
+  normalized renderer state; `IDLE` after `PLAYING` can auto-advance the queue
+- Registry registers Cast alongside UPnP when dependencies are available
+
+Verification so far:
+
+- Targeted server slice passed:
+  `./test.sh tests/unit/test_renderer_phase2_cast.py tests/api/test_renderer_phase2_api.py tests/unit/test_renderer_phase1.py tests/api/test_renderer_phase1_api.py tests/api/test_player.py tests/api/test_stream.py`
+  -> 41 passed
+- Full server gate passed: `./test.sh` -> 343 passed, 1 skipped
+
+Still required before calling Phase 2 fully delivered:
+
+- Real-device smoke on one Chromecast/Google Home
+
 ### 2.1 Dependencies
 
 ```

--- a/plan-chromecast.md
+++ b/plan-chromecast.md
@@ -1,0 +1,1112 @@
+# Chromecast Playback — Implementation Plan
+
+## Architecture
+
+Build a single renderer orchestration layer with pluggable backend implementations.
+Frontend clients and player API endpoints should deal with one renderer model and
+one control API. Protocol-specific details stay inside backend adapters.
+
+```
+Web / Android
+    |
+    v
+Player API
+    |
+    v
+RendererOrchestrator
+    |-- queue state
+    |-- stream URL/token creation
+    |-- auto-advance
+    |-- progress/history/scrobble updates
+    |-- renderer API response shape
+    |
+    v
+RendererRegistry
+    |-- upnp:<udn>  -> UpnpRendererBackend
+    |-- cast:<uuid> -> CastRendererBackend
+    |-- local:<id>  -> local client playback state
+```
+
+Backend responsibilities:
+
+- Discover devices
+- Persist/update renderer device metadata
+- Translate play/pause/resume/stop/seek/volume/status calls into protocol calls
+- Emit or expose device playback status/progress
+- Hide protocol-native IDs, status strings, connection lifecycle, and libraries
+
+Orchestrator responsibilities:
+
+- Own canonical renderer identity
+- Own queue state and active renderer state
+- Create stream/artwork URLs with the correct token policy
+- Trigger protocol backend playback
+- Normalize progress/status into DB state
+- Auto-advance tracks
+- Log history and Last.fm state
+- Serve one frontend/API contract
+
+Renderer identity is canonical and backend-agnostic:
+
+```
+renderer_id = "{kind}:{native_id}"
+```
+
+Examples:
+
+- `upnp:uuid:...`
+- `cast:8f1c...`
+- `local:web-client-id`
+
+The old `udn` field remains accepted temporarily for backwards compatibility,
+but new code should pass `renderer_id` and `kind`. Avoid adding new API surfaces
+that assume every remote renderer has a UPnP UDN.
+
+Two Cast control paths still exist:
+
+| Path | Who discovers | Who controls | Server location | Use case |
+|---|---|---|---|---|
+| **Server-driven Cast** | Server (mDNS) | Server (`pychromecast`) | Same LAN as Cast devices | Home server, Docker on NAS |
+| **Device-direct Cast** | Android (MediaRouter/Cast SDK) | Android | Anywhere public | VPS, public internet server |
+
+Both Cast paths: Cast device fetches stream URL from server over HTTP. Default
+Media Receiver handles playback. No custom receiver app for v1.
+
+### Architecture reference — Music Assistant
+
+Use Music Assistant's provider tree as an architecture reference, not as a
+dependency:
+
+- [`_demo_player_provider`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/_demo_player_provider)
+  shows the smallest useful shape for a player provider: setup, discovery,
+  register/update, unload, and per-player command methods.
+- [`chromecast`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/chromecast)
+  is the closest reference for Cast discovery, manual known-host discovery,
+  duplicate discovery suppression, app launch, status callbacks, volume mapping,
+  and Cast group handling.
+- [`dlna`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/dlna)
+  is the closest reference for UPnP/DLNA discovery, event subscription with
+  polling fallback, manual reconnect, transport-state mapping, and renderer
+  quirks such as passive speakers.
+- [`airplay`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/airplay)
+  is a future reference for capability differences, pairing/auth, fixed output
+  formats, and stream/session-based playback.
+- [`local_audio`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/local_audio)
+  is a useful reference for local playback as a backend with limited capabilities.
+- [`universal_player`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/universal_player)
+  is a future reference for logical renderers that wrap one or more protocol
+  renderers.
+- [`sync_group`](https://github.com/music-assistant/server/tree/dev/music_assistant/providers/sync_group)
+  is a future reference for grouped renderers and leader selection. Ignore for v1.
+
+Concepts to borrow:
+
+- Small provider/backend interface, not a full plugin ecosystem
+- Separate provider/backend object from per-device player object
+- Explicit capability model per renderer
+- Normalized playback state independent of protocol-native status strings
+- Discovery callbacks that update existing devices instead of duplicating them
+- Manual discovery/address handling per backend
+- Event callbacks where available, polling fallback where needed
+- Per-protocol quirks contained inside the backend
+- Logical renderers and sync groups later, after real devices are stable
+
+### Delivery rules
+
+- Build phases in order. Do not start a phase until the previous phase's delivery
+  gate is satisfied.
+- Keep phases mergeable independently. Each phase should leave local playback and
+  existing UPnP behavior working.
+- Prefer fake backend tests for orchestration logic. Use real device smoke tests
+  only for protocol/library behavior that cannot be mocked reliably.
+- Do not add a new protocol path directly to `player.py`. All new backend work
+  must go through registry/orchestrator.
+- Every endpoint/API shape change must keep backwards compatibility until web and
+  Android callers have moved to `renderer_id`.
+
+### Test commands
+
+Run the relevant subset for each slice, then full gates before phase completion:
+
+- Server tests: `./test.sh`
+- Targeted server tests: `./test.sh tests/api/test_player.py tests/api/test_stream.py`
+- Web tests: `cd web && npm run check && npm test`
+- Web build: `cd web && npm run build`
+- Android tests/build: `android/test.sh`
+- Android instrumentation when device/emulator is available:
+  `RUN_ANDROID_INSTRUMENTATION=1 android/test.sh`
+
+---
+
+## Phase 0 — Baseline & Characterization
+
+Before changing architecture, lock down current behavior so refactors can move
+internals without changing user-visible playback.
+
+### 0.1 Current behavior inventory
+
+- List every player endpoint that touches `UPnPManager`
+- Document current local, server-UPnP, and Android device-UPnP flows
+- Document DB ownership:
+  - `client_session.active_renderer_udn`
+  - `renderer_state.renderer_udn`
+  - queue/current index/progress/volume fields
+- Capture current stream-token behavior for browser, Android, and UPnP playback
+- Capture current monitor behavior: polling interval, STOPPED detection,
+  auto-advance, history logging, Last.fm now-playing updates
+
+### 0.2 Test fixtures
+
+- Add fake renderer/backend fixtures that record commands without touching network
+- Add fake status event helpers for `PLAYING`, `PAUSED`, `STOPPED`, `IDLE`,
+  progress updates, volume updates, and track-ended events
+- Add sample renderer IDs:
+  - `local:test-client`
+  - `upnp:uuid:test-upnp`
+  - `cast:test-cast-uuid`
+
+### 0.3 Required test coverage
+
+- API characterization tests for queue set, play, pause, resume, seek, volume,
+  skip/index, clear queue, renderer selection, and `/api/player/state`
+- Monitor characterization tests for auto-advance and history threshold logging
+- Stream token tests proving existing 300s default behavior remains unchanged
+  until the Cast token policy is introduced
+- Existing `tests/api/test_player.py` and `tests/api/test_stream.py` must pass
+
+### 0.4 Exit criteria
+
+- Current UPnP and local playback behavior is covered by tests or explicitly
+  documented as manual-only
+- Fake backend/status fixtures exist and can be reused by Phase 1 tests
+- No production behavior changes in this phase
+
+---
+
+## Phase 1 — Unified Renderer Backend API (Foundation)
+
+Both Cast paths and future protocols need this. Without it, every player endpoint
+and monitor path grows protocol checks (`if kind == "cast"`, `if kind == "upnp"`).
+Phase 1 should prove the contract by moving existing UPnP behavior behind the
+same backend API Cast will use.
+
+Delivery strategy: ship this in small slices with UPnP behavior preserved at
+each step. Do not add Chromecast control until UPnP works through the new
+orchestrator.
+
+### 1.1 DB migration
+
+```
+migrations/029_renderer_kind.sql
+```
+
+- Add `kind TEXT DEFAULT 'upnp'` to `renderer` table
+- Add `native_id TEXT` column (UDN for UPnP, UUID for Cast)
+- Add `renderer_id TEXT UNIQUE` column, canonical `{kind}:{native_id}`
+- Backfill existing UPnP rows:
+  - `kind = 'upnp'`
+  - `native_id = udn`
+  - `renderer_id = 'upnp:' || udn`
+- Add `cast_uuid TEXT UNIQUE` column (Cast device UUID, nullable compatibility field)
+- Add `cast_type TEXT` column (Chromecast, Google Home, Cast Group, Android TV, etc.)
+- Add `last_discovered_by TEXT DEFAULT 'server'` column (`server`/`device`)
+- Add `active_renderer_id TEXT` to `client_session`, or replace `active_renderer_udn`
+  once compatibility work is complete
+- Keep `active_renderer_udn` readable during migration for old clients/tests
+- Consider renaming `renderer_state.renderer_udn` later; for now store canonical
+  `renderer_id` in that column to minimize migration blast radius
+
+### 1.2 Backend contracts
+
+```
+app/services/renderer/contracts.py
+```
+
+Define protocol-neutral dataclasses:
+
+```python
+@dataclass
+class RendererCapabilities:
+    can_play: bool = True
+    can_pause: bool = True
+    can_stop: bool = True
+    can_seek: bool = True
+    can_set_volume: bool = True
+    can_mute: bool = False
+    can_next_previous: bool = False
+    can_enqueue: bool = False
+    can_group: bool = False
+    can_power: bool = False
+    reports_progress: bool = True
+    supports_events: bool = False
+    requires_flow_mode: bool = False
+    supported_mime_types: set[str] = field(default_factory=set)
+
+@dataclass
+class RendererDevice:
+    renderer_id: str
+    kind: str
+    native_id: str
+    name: str
+    ip: str | None = None
+    manufacturer: str | None = None
+    model_name: str | None = None
+    cast_type: str | None = None
+    discovered_by: str = "server"
+    capabilities: RendererCapabilities = field(default_factory=RendererCapabilities)
+    available: bool = True
+    enabled_by_default: bool = True
+    is_group: bool = False
+    group_members: list[str] = field(default_factory=list)
+
+@dataclass
+class RendererStatus:
+    renderer_id: str
+    state: str  # PLAYING, PAUSED, STOPPED, BUFFERING, IDLE, UNKNOWN
+    position_seconds: float = 0
+    duration_seconds: float | None = None
+    volume_percent: int | None = None
+    volume_muted: bool | None = None
+    current_track_id: int | None = None
+    current_media_url: str | None = None
+    active_source: str | None = None
+    available: bool = True
+    ended: bool = False
+
+@dataclass
+class PlaybackContext:
+    base_url: str
+    user_id: int | None
+    username: str | None = None
+    token_ttl_seconds: int | None = None
+```
+
+Define `RendererBackend`:
+
+```python
+class RendererBackend(Protocol):
+    kind: str
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+
+    async def discover(self, refresh: bool = False) -> list[RendererDevice]: ...
+    async def add_manual(self, address: str) -> RendererDevice | None: ...
+    async def list_devices(self) -> list[RendererDevice]: ...
+    async def unload_device(self, renderer_id: str) -> None: ...
+
+    async def play_track(
+        self,
+        renderer_id: str,
+        track: dict,
+        context: PlaybackContext,
+    ) -> RendererStatus: ...
+
+    async def pause(self, renderer_id: str) -> RendererStatus: ...
+    async def resume(self, renderer_id: str) -> RendererStatus: ...
+    async def stop_playback(self, renderer_id: str) -> RendererStatus: ...
+    async def seek(self, renderer_id: str, seconds: float) -> RendererStatus: ...
+    async def set_volume(self, renderer_id: str, percent: int) -> RendererStatus: ...
+    async def mute(self, renderer_id: str, muted: bool) -> RendererStatus: ...
+    async def get_status(self, renderer_id: str) -> RendererStatus: ...
+```
+
+Optional callback interface for event-capable protocols:
+
+```python
+class SupportsStatusEvents(Protocol):
+    def register_status_listener(
+        self,
+        renderer_id: str,
+        callback: Callable[[RendererStatus], Awaitable[None]],
+    ) -> Callable[[], None]: ...
+```
+
+UPnP can use polling. Cast can use media-controller callbacks. The orchestrator
+should not care which mechanism produced a `RendererStatus`.
+
+### 1.3 Renderer registry
+
+```
+app/services/renderer/registry.py
+```
+
+- Own backend instances keyed by `kind`
+- Parse canonical `renderer_id`
+- `get_backend(renderer_id) -> RendererBackend`
+- `list_all() -> list[RendererDevice]`
+- `discover_all(refresh=False) -> list[RendererDevice]`
+- `get_device(renderer_id) -> RendererDevice | None`
+- `set_active(client_id, renderer_id)` updates `client_session.active_renderer_id`
+- Compatibility lookup: accept old UDN and map to `upnp:<udn>` when possible
+
+### 1.4 Renderer orchestrator
+
+```
+app/services/renderer/orchestrator.py
+```
+
+Own the playback behavior that is currently spread across `player.py`,
+`monitor.py`, and `queue.py`:
+
+- `play_queue(client_id, queue, start_index, user, request_context)`
+- `play_track(client_id, track_id, user, request_context)`
+- `pause(client_id)`
+- `resume(client_id)`
+- `stop(client_id)`
+- `seek(client_id, seconds)`
+- `set_volume(client_id, percent)`
+- `skip_to_index(client_id, index)`
+- `handle_status(renderer_id, status)`
+- `advance_queue(renderer_id)`
+- `start_monitor(renderer_id)`
+- `stop_monitor(renderer_id)`
+
+Orchestrator rules:
+
+- Local playback remains state-only; clients play audio themselves
+- Remote playback always calls a backend via registry
+- Queue updates, current index, progress, auto-advance, and history stay
+  protocol-neutral
+- Backend status strings are normalized before reaching DB/API
+- `play_next_track_internal()` moves here and stops importing `UPnPManager`
+- Capability checks happen before commands; unsupported commands become clear API
+  errors or no-op fallbacks decided by orchestrator
+- Backends may optimistically update status after a command, but orchestrator is
+  the only layer that persists normalized player state
+
+### 1.5 Shared renderer persistence
+
+```
+app/services/renderer/persistence.py
+```
+
+Borrow the Music Assistant idea of register/update semantics:
+
+- `register_or_update(RendererDevice)` upserts renderer metadata by `renderer_id`
+- Discovery callbacks update existing renderers in place
+- Removed/unreachable devices mark `available = false`; do not immediately delete
+- Disabled renderers stay persisted and are ignored by discovery/control
+- Manual-discovery addresses are backend config, not global player API special cases
+- Keep protocol-specific device info (`cast_type`, `supported_mime_types`, group
+  details) in normalized columns or JSON metadata, but keep player API response flat
+
+### 1.6 Backend/device split
+
+Use a two-layer internal structure, matching the useful part of Music Assistant:
+
+- Backend/provider object owns discovery, shared clients, lifecycle, caches, and
+  manual addresses
+- Per-device object owns native connection/control/status for one renderer
+
+Examples:
+
+- `UpnpRendererBackend` owns SSDP discovery, HTTP requester/session, notify server
+  if added later, and UDN/device cache
+- `UpnpRendererDevice` owns one DMR wrapper and UPnP command/status mapping
+- `CastRendererBackend` owns `CastBrowser`, known hosts, discovery lock, and UUID cache
+- `CastRendererDevice` owns one `pychromecast.Chromecast`, media controller,
+  status listeners, app launch, and group metadata
+
+Keep this split internal. Public code still depends only on `RendererBackend`.
+
+### 1.7 UPnP backend
+
+```
+app/services/renderer/upnp_backend.py
+```
+
+Wrap existing `UPnPManager`/`UPnPDeviceControl` behind `RendererBackend`.
+
+- Use existing UPnP discovery/control code initially
+- Convert UPnP UDN to canonical `upnp:<udn>`
+- Keep current UPnP polling monitor, but emit normalized `RendererStatus`
+- Add/route real `stop_playback()` support; current facade lacks a stop method
+- Keep UPnP MIME selection and DIDL generation inside UPnP backend
+- No Cast logic in UPnP backend
+- Map `TransportState.PLAYING`/`TRANSITIONING` to `PLAYING`
+- Map `PAUSED_PLAYBACK`/`PAUSED_RECORDING` to `PAUSED`
+- Map unknown/vendor states to `IDLE` or `UNKNOWN`, not raw strings
+- Treat event subscription as optional; always keep polling fallback
+- Detect passive/non-playable renderers and ignore or disable them
+
+### 1.8 Refactor player.py
+
+All player endpoints switch from direct `UPnPManager` usage:
+```python
+await upnp.set_renderer(udn)
+await upnp.play_track(...)
+```
+to:
+```python
+await renderer_orchestrator.play_track(client_id, track_id, user, request_context)
+```
+
+Endpoints should not import `UPnPManager`, `CastManager`, `pychromecast`, or
+protocol-specific modules. They should only use orchestrator/registry.
+
+### 1.9 Stream token policy
+
+Cast receivers parse the URL once — they don't re-auth. Current 300s TTL is too short for a 10-minute track.
+
+- Add token TTL policy to orchestrator, not individual backends
+- Add `CAST_STREAM_TOKEN_TTL_SECONDS` env var, default `86400` (24h) unless
+  duration-based TTL is chosen before implementation
+- Prefer duration-based TTL when `duration_seconds` is available:
+  `max(1800, duration_seconds * 2)` capped at configured maximum
+- When `kind == "cast"`, create token with Cast TTL
+- Token still bound to track_id — scope is narrow even with long TTL
+- Reissuing a stateless JWT does **not** invalidate previous URLs. If stale-token
+  invalidation is required, add token nonce/version persistence and verify it in
+  `/api/stream/{track_id}`
+- Alternative considered but deferred: LAN-allowlist bypass (breaks auth model)
+
+### 1.10 Unified monitor/status entry point
+
+```
+app/services/player/monitor.py (modify)
+```
+
+- `start_monitor(renderer_id)` dispatches through registry/backend capability
+- UPnP backend uses poll loop and reports `RendererStatus`
+- Cast backend subscribes to `pychromecast` media controller callbacks
+- Orchestrator handles normalized status:
+  - progress updates
+  - volume sync
+  - track-ended detection
+  - auto-advance via `advance_queue(renderer_id)`
+  - history/scrobble updates
+- Avoid backend-specific calls from monitor code
+
+### 1.11 Renderer API responses
+
+- `/api/renderers` returns unified renderer objects:
+  - `renderer_id`
+  - `kind`
+  - `native_id`
+  - `udn` (compat for UPnP)
+  - `name`
+  - `ip`
+  - `manufacturer`
+  - `model_name`
+  - `cast_type`
+  - `discovered_by`
+  - `capabilities`
+- `/api/player/renderer` accepts `renderer_id`; accept `udn` as compatibility
+- `/api/player/state` response includes `renderer_id` and `renderer_kind`
+- Android/web should use `renderer_id` for new selections
+
+### 1.12 Development slices
+
+1. Contract-only slice:
+   - Add `contracts.py`
+   - Add fake backend implementation for tests
+   - No endpoint behavior changes
+
+2. Persistence slice:
+   - Add migration
+   - Add renderer persistence helpers
+   - Backfill existing UPnP renderers
+   - Keep old `udn` reads working
+
+3. Registry slice:
+   - Add `RendererRegistry`
+   - Register fake backend in tests
+   - Register UPnP backend behind feature flag or internal wiring
+   - `/api/renderers` can return both old and new fields
+
+4. Orchestrator read/write slice:
+   - Move active renderer lookup/update into registry/orchestrator
+   - Move queue/state writes behind orchestrator
+   - Keep actual playback calls routed to existing UPnP path until tests pass
+
+5. UPnP backend slice:
+   - Wrap existing UPnP discovery/control
+   - Commands flow through `RendererBackend`
+   - Monitor emits normalized `RendererStatus`
+
+6. Endpoint cutover slice:
+   - Remove direct `UPnPManager` imports from `player.py`
+   - Player endpoints call orchestrator only
+   - Compatibility `udn` input still accepted
+
+7. Cleanup slice:
+   - Delete dead UPnP-specific monitor/queue paths only after all tests pass
+   - Keep thin compatibility adapters if Android/web still rely on old response
+     fields
+
+### 1.13 Required test coverage
+
+- Unit tests for `RendererCapabilities`, `RendererDevice`, `RendererStatus`, and
+  renderer ID parsing/formatting
+- Migration tests:
+  - Existing renderer rows backfill to `upnp:<udn>`
+  - `client_session` compatibility still reads old active renderer values
+  - New `renderer_id` uniqueness is enforced
+- Registry tests:
+  - Backend lookup by `renderer_id`
+  - Legacy UDN maps to `upnp:<udn>`
+  - Unknown kind and unknown renderer fail cleanly
+  - `discover_all()` merges multiple backends without duplicate IDs
+- Persistence tests:
+  - `register_or_update()` creates and updates devices
+  - Removed devices mark unavailable, not deleted
+  - Disabled renderer is ignored for control
+- Orchestrator API tests with fake backend:
+  - queue set/play calls backend with expected track/context
+  - pause/resume/stop/seek/volume route to active backend
+  - unsupported capability returns clear API error or documented no-op
+  - status events update DB state
+  - `ended=True` advances queue once
+  - duplicate/end-of-load events do not double-advance
+- UPnP adapter tests:
+  - transport state mapping
+  - volume scaling remains unchanged
+  - stream URL and artwork URL generated as before
+  - stop fallback works for devices with/without stop action
+- Regression tests:
+  - Existing local playback API behavior unchanged
+  - Existing server-UPnP endpoint tests pass
+  - Existing stream/auth tests pass
+
+### 1.14 Delivery gate
+
+- Web app can still play locally and control existing UPnP renderers
+- Android device-UPnP still works
+- `/api/renderers`, `/api/player/renderer`, and `/api/player/state` expose new
+  fields while staying backwards-compatible
+- `app/api/player.py` no longer imports protocol-specific backend libraries
+- Fake backend tests cover the protocol-neutral orchestration path
+
+**Files touched:** ~12
+**New files:** ~6
+**Migration:** 1
+
+---
+
+## Phase 2 — Server-Driven Cast
+
+Server discovers and controls Cast devices on same LAN. Useful for home-server deployments (Docker on NAS, Pi, etc.).
+
+### 2.1 Dependencies
+
+```
+pyproject.toml
+```
+
+Add `pychromecast>=14.0.0` and `zeroconf>=0.130.0` (if not already a transitive dep).
+
+### 2.2 Cast backend (`app/services/renderer/cast_backend.py`)
+
+- `CastRendererBackend` implements `RendererBackend`
+- mDNS browser for `_googlecast._tcp.local` via `pychromecast.discovery`
+- Accept manual known hosts / manual IPs in backend config
+- Guard discovery callbacks with a lock and a pending-discovery set so the same
+  UUID is not created twice while async setup is still running
+- Parse Cast device info into `RendererDevice`:
+  - `renderer_id = "cast:{uuid}"`
+  - `kind = "cast"`
+  - `native_id = uuid`
+  - `cast_type = audio/display/group/android_tv/etc.`
+- Manual IP entry via `add_manual(address)` for VLAN scenarios
+- Persist through shared renderer persistence, not a Cast-specific save path
+- `discover(refresh=True)` scans and returns normalized `RendererDevice` objects
+- `list_devices()` returns cached devices
+- Ignore dynamic/ephemeral Cast groups if they are not stable enough for v1
+- Ignore passive multichannel child endpoints; expose the usable group/parent
+
+### 2.3 Cast control behavior
+
+- Backend wraps `pychromecast.Chromecast`
+- `play_track()`: `cast.media_controller.play_media(url, content_type)` with metadata
+- `pause()`: `cast.media_controller.pause()`
+- `resume()`: `cast.media_controller.play()`
+- `stop_playback()`: `cast.media_controller.stop()`
+- `seek()`: `cast.media_controller.seek(seconds)`
+- `set_volume()`: `cast.set_volume(percent / 100.0)`
+- `get_status()` maps `cast.media_controller.status` to `RendererStatus`
+- Metadata passed via `pychromecast.controllers.media.MediaMetadata` (title, artist, album, images for artwork)
+- Artwork URL included in metadata — Cast receiver fetches it directly
+- App launch is explicit:
+  - Default Media Receiver for v1
+  - Wait for launch callback/event with timeout
+  - Treat timeout as renderer unavailable/failure, not silent success
+- Cast callbacks happen on pychromecast/socket threads; dispatch state mutation
+  back onto the asyncio event loop
+- Cast receiver codec support must be explicit. If v1 does not transcode, document
+  unsupported codecs/containers as expected failures.
+
+### 2.4 Cast status events
+
+- Implement `register_status_listener(renderer_id, callback)` if practical with
+  `cast.media_controller.register_status_listener()`
+- Callback-driven, no poll loop
+- Convert Cast states to normalized `RendererStatus`
+- On `PLAYING` → emit position/transport update
+- On `IDLE` with previous state `PLAYING` → emit `ended=True`
+- Grace period after `play_track()` (3s) to ignore transient `IDLE` during load
+- Volume changes synced on callback
+- Orchestrator receives events and owns DB updates/auto-advance
+
+### 2.5 main.py wiring
+
+- Register `CastRendererBackend` with `RendererRegistry` in FastAPI lifespan startup
+- `startup`: `await registry.start_all()`
+- `shutdown`: `await registry.stop_all()`
+- No `CastManager` singleton; registry owns backend lifecycles
+
+### 2.6 Development slices
+
+1. Dependency/import slice:
+   - Add dependencies
+   - Add backend skeleton
+   - Backend can start/stop without network discovery enabled
+
+2. Discovery slice:
+   - Add mDNS discovery and manual known hosts
+   - Convert pychromecast device info into `RendererDevice`
+   - Persist devices through shared persistence
+   - Mark unavailable on connection loss/removal callback
+
+3. Command slice:
+   - Implement play/pause/resume/stop/seek/volume/get_status
+   - Launch Default Media Receiver explicitly with timeout
+   - Generate Cast-safe stream URL through orchestrator token policy
+
+4. Status/event slice:
+   - Register media/cast status listeners
+   - Dispatch callbacks onto asyncio loop
+   - Normalize Cast state into `RendererStatus`
+   - Feed status into orchestrator
+
+5. End-to-end slice:
+   - Server-discovered Cast devices appear in `/api/renderers`
+   - Web can select Cast renderer and use existing player controls
+   - Auto-advance works from Cast ended event
+
+### 2.7 Required test coverage
+
+- Unit tests with mocked `pychromecast`:
+  - discovery creates `cast:<uuid>` renderer IDs
+  - duplicate discovery does not create duplicate devices
+  - manual known host is passed to Cast browser
+  - dynamic groups/passive endpoints are filtered according to v1 policy
+  - app launch success, timeout, and failure paths
+  - command methods call pychromecast APIs with expected values
+  - volume maps 0-100 to 0.0-1.0 and back
+  - callback thread handoff schedules event-loop updates
+  - Cast states map to normalized `RendererStatus`
+- Orchestrator integration tests with fake Cast backend:
+  - Cast token TTL policy is used
+  - `IDLE` after `PLAYING` emits one queue advance
+  - transient `IDLE` during load grace period is ignored
+  - volume/status callbacks update `renderer_state`
+- API tests:
+  - `/api/renderers` returns UPnP and Cast devices together
+  - `/api/player/renderer` accepts `renderer_id=cast:<uuid>`
+  - play/pause/resume/seek/volume endpoints route to Cast backend
+- Optional manual smoke:
+  - One real Chromecast or Google Home on LAN
+  - Start playback, pause, seek, volume, skip, end-of-track auto-advance
+
+### 2.8 Delivery gate
+
+- Server-driven Cast is usable from web with the existing player controls
+- Existing UPnP and local tests still pass
+- Cast device disconnect does not crash server or leave monitor task stuck
+- Unsupported Cast codecs are documented or covered by an explicit error path
+
+**Files touched:** ~5
+**New files:** ~2
+
+---
+
+## Phase 3 — Android Device-Direct Cast
+
+Android phone discovers and controls Cast devices directly on the same Wi-Fi as the Cast device. Phone calls server REST API for stream URLs, but Cast protocol goes phone ↔ Cast device. Works when server is public (VPS) or on different network.
+
+### 3.1 Dependencies
+
+```
+android/app/build.gradle.kts
+```
+
+Add Google Play Services Cast SDK:
+```kotlin
+implementation("com.google.android.gms:play-services-cast:21.5.0")
+implementation("com.google.android.gms:play-services-cast-framework:21.5.0")
+```
+
+Requires Google Play Services on device (standard on all Google-certified Android).
+
+### 3.2 Android renderer controller contract
+
+Mirror the backend architecture on Android so the ViewModel does not need a
+branch for every protocol.
+
+```
+android/.../renderer/DeviceRendererController.kt
+```
+
+Common contract:
+
+```kotlin
+interface DeviceRendererController {
+    val kind: String
+    val renderers: StateFlow<List<DeviceRendererInfo>>
+    val state: StateFlow<DeviceRendererPlaybackState>
+
+    fun start()
+    fun stop()
+    fun search()
+    fun selectRenderer(rendererId: String)
+
+    suspend fun playQueue(tracks: List<QueuedTrack>, startIndex: Int)
+    suspend fun pause()
+    suspend fun resume()
+    suspend fun stopPlayback()
+    suspend fun seek(seconds: Double)
+    suspend fun setVolumePercent(percent: Int)
+    suspend fun next()
+    suspend fun previous()
+    suspend fun jumpTo(index: Int)
+}
+```
+
+Existing `UpnpDeviceController` becomes first implementation. New
+`CastDeviceController` becomes second implementation.
+
+### 3.3 Cast device controller (`android/.../cast/CastDeviceController.kt`)
+
+New class implementing `DeviceRendererController`:
+
+- **Discovery**: `MediaRouter` with `MediaRouteSelector` for Cast routes (`"com.google.android.gms.cast.CATEGORY_CAST"`)
+- **Renderer list**: `StateFlow<List<DeviceRendererInfo>>` with canonical `cast:<uuid>` renderer IDs
+- **Control**:
+  - `selectRenderer(rendererId)` → connect via `CastContext.getSharedInstance().sessionManager`
+  - `playQueue(tracks, startIndex)` → build `MediaQueueItem` list from tracks, load into `RemoteMediaClient`
+  - `pause()`, `resume()`, `seek()`, `setVolume()` → delegate to `RemoteMediaClient`
+  - `next()`, `previous()` → `RemoteMediaClient.queueJumpToItem()`
+- **Position polling**: `RemoteMediaClient.addProgressListener()` with 1s interval, similar to UPnP
+- **Auto-advance**: on `MediaStatus.MEDIA_STATUS_FINISHED`, advance queue internally and `queueJumpToItem()`
+- Track metadata: `MediaMetadata` with title, artist, album, artwork URL
+- Volume: 0.0-1.0 float internally, expose 0-100 to match app convention
+
+### 3.4 Cast SDK app config
+
+Cast Framework requires app configuration beyond Gradle dependencies:
+
+- Add `OptionsProvider` implementation
+- Add required `com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME`
+  manifest metadata
+- Use Default Media Receiver app ID for v1
+- Verify behavior on devices without Google Play Services and report clear UI state
+
+### 3.5 `QueuedTrack` — stream URL resolution
+
+Same data class as UPnP's `QueuedTrack`. Stream URL obtained from server REST API (`/api/stream-url/{track_id}`) before building `MediaQueueItem` list. Cast device fetches the URL directly — phone does not proxy audio.
+
+For Cast, request a Cast-safe stream token policy. Options:
+
+- Add query parameter to `/api/stream-url/{track_id}?renderer_kind=cast`
+- Add a new request body endpoint if token policy needs more context
+- Or have server infer Cast from active renderer when device-direct Cast pins the
+  server active renderer to `local:<clientId>`
+
+### 3.6 ViewModel integration (`JamarrViewModel.kt`)
+
+- Replace protocol-specific branching with an active `DeviceRendererController`
+  where practical
+- `RendererSource` enum gains `DEVICE_CAST` or uses `DEVICE` plus `kind`
+- Renderer picker can show separate device sections, but selection stores canonical
+  `renderer_id`
+- Unified device-mode toggle controls both UPnP + Cast discovery unless UX needs
+  separate toggles
+- Playback actions dispatch to active controller contract, not concrete UPnP/Cast classes
+- Device-direct Cast should pin server active renderer to `local:<clientId>` and
+  report queue/progress/index through existing server APIs so history/scrobble
+  behavior matches Android device-UPnP
+
+### 3.7 Renderer picker UI
+
+```
+android/.../ui/components/RendererPicker.kt (modify)
+```
+
+- Add "Cast" section header when device mode is on and Cast devices are found
+- `CastIcon` composable already exists in file (line 272) — no icon work needed
+- Server-rendered Cast devices appear in server section (discovered by Phase 2), device-discovered Cast devices appear in device section
+
+### 3.8 Cast button (optional)
+
+Android Cast SDK includes `MediaRouteButton` for discovery. Can add to PlayerBar as quality-of-life. Not required for v1 — renderer picker is sufficient.
+
+### 3.9 Development slices
+
+1. Android controller contract slice:
+   - Add `DeviceRendererController`
+   - Adapt `UpnpDeviceController` to the interface
+   - ViewModel can still use UPnP through the contract
+
+2. Cast SDK setup slice:
+   - Add dependencies
+   - Add `OptionsProvider`
+   - Add manifest metadata
+   - Add Play Services availability handling
+
+3. Cast discovery slice:
+   - Discover Cast routes
+   - Expose `DeviceRendererInfo` with `cast:<uuid>` IDs
+   - Show Cast devices in renderer picker
+
+4. Cast playback slice:
+   - Resolve stream URLs with Cast token policy
+   - Build `MediaQueueItem` list
+   - Load queue into `RemoteMediaClient`
+   - Implement pause/resume/seek/volume/next/previous/jump
+
+5. Progress/history slice:
+   - Report queue to server under `local:<clientId>`
+   - Report progress/index to server like device-UPnP
+   - Keep history and Last.fm behavior consistent
+
+6. UX slice:
+   - Add Cast section in renderer picker
+   - Add optional Cast button only after renderer picker path works
+   - Show clear unavailable state when Play Services or Cast session fails
+
+### 3.10 Required test coverage
+
+- Android unit tests:
+  - `DeviceRendererController` contract behavior using fake controller
+  - ViewModel dispatch routes to active controller by source/kind
+  - Device-UPnP still reports queue/progress through the contract
+  - Cast stream URL requests use selected Cast token policy
+  - progress/index reporting works for device-direct Cast
+  - renderer picker state stores canonical `renderer_id`
+- Cast controller tests with fakes/mocks where feasible:
+  - discovered route becomes `cast:<uuid>`
+  - queue item metadata contains title/artist/album/artwork
+  - volume maps 0-100 to Cast float
+  - progress listener updates state
+  - finished status advances internal queue and reports index
+- UI tests:
+  - renderer picker shows local, server, device-UPnP, and device-Cast sections
+  - selecting Cast updates active renderer/source
+  - missing Play Services shows non-crashing disabled/unavailable state
+- Manual device smoke:
+  - Android phone and Cast device on same Wi-Fi
+  - Server can be on another network/public URL
+  - Play, pause, seek, volume, skip, queue advance, history logging
+
+### 3.11 Delivery gate
+
+- Android can choose device-direct Cast without server LAN discovery
+- Device-direct Cast logs history/scrobbles via existing progress path
+- Android device-UPnP remains working through the new controller contract
+- App handles no Play Services and failed Cast session without crash
+
+**Files touched:** ~5
+**New files:** ~3
+
+---
+
+## Phase 4 — Web App Cast UI
+
+### 4.1 Renderer icons
+
+```
+web/src/lib/components/RendererPicker.svelte (modify)
+```
+
+- `CastIcon.svelte` — SVG cast icon (rectangle + WiFi arcs)
+- `SpeakerIcon.svelte` — existing speaker for UPnP
+- Show correct icon per `kind` field from `/api/renderers`
+
+### 4.2 No other changes
+
+Web app already talks to server REST API. Cast devices discovered by Phase 2 appear alongside UPnP. No new control flow.
+
+### 4.3 Required test coverage
+
+- Web unit/component tests:
+  - renderer picker renders Cast icon for `kind="cast"`
+  - renderer picker still renders UPnP/local renderers
+  - selecting a renderer sends `renderer_id`
+  - old `udn` fallback still works if API returns compatibility fields
+- API/client tests:
+  - player store accepts `renderer_id` and `renderer_kind`
+  - state polling does not drop unknown future renderer kinds
+- Manual browser smoke:
+  - select local renderer
+  - select UPnP renderer
+  - select server Cast renderer
+  - play/pause/seek/volume still call same API endpoints
+
+### 4.4 Delivery gate
+
+- Web UI needs no protocol-specific control path beyond icon/label rendering
+- Existing web playback behavior unchanged for local and UPnP
+
+**Files touched:** ~2
+**New files:** ~1
+
+---
+
+## Phase 5 — Future Backend Shapes
+
+These are not required for Chromecast v1, but the Phase 1 contract should avoid
+blocking them.
+
+### 5.1 Local audio backend
+
+Use Music Assistant `local_audio` as a reference for a backend with narrow
+capabilities.
+
+- `local:<clientId>` stays frontend-controlled for web/mobile today
+- A future server-local backend could expose host soundcards as `local_audio:<id>`
+- Capability model must support volume-only or no-playback devices cleanly
+- Hardware volume can fail; support fallback to software/app volume
+
+### 5.2 Universal/logical renderer
+
+Use Music Assistant `universal_player` as a reference only.
+
+- Logical renderer wraps one or more protocol renderers for the same physical
+  device
+- Useful later when a device exposes both DLNA and Cast/AirPlay
+- Prefer active external source/protocol based on current status
+- Do not implement until physical-device matching is stable
+
+### 5.3 Sync group renderer
+
+Use Music Assistant `sync_group` as a reference only.
+
+- Group renderer owns queue and delegates playback to a selected leader/member
+- Needs leader selection, member compatibility, dissolve/reform, and progress
+  ownership rules
+- Defer until single-renderer Cast/DLNA behavior is reliable
+
+### 5.4 Required test coverage before implementing any future backend
+
+- Backend contract conformance tests reused from UPnP/Cast
+- Capability matrix tests proving unsupported commands are handled consistently
+- Logical renderer tests proving wrapped renderers do not duplicate history or
+  fight over queue ownership
+- Group tests proving leader changes do not double-advance or double-log plays
+
+---
+
+## Phase 6 — Edge Cases & Hardening
+
+### 6.1 Cast groups (speaker groups)
+
+Google Home speaker groups appear as single `CastDevice` with `cast_type = "group"`. `pychromecast` handles them transparently — the group UUID maps to a `Chromecast` object that routes audio to all members. No special handling required. Verify volume/position reporting works sensibly across group members.
+
+### 6.2 Device reconnect
+
+Cast devices can disconnect (power off, network change). Both control paths need reconnect logic:
+- Server: `pychromecast` has auto-reconnect. Re-verify on monitor error.
+- Android: `SessionManagerListener` handles session lifecycle.
+
+### 6.3 Switching renderer mid-session
+
+Orchestrator handles this protocol-neutrally: stop current backend renderer,
+persist active `renderer_id`, reset/reload queue state as needed, then call the
+new backend. Do not leave switching behavior inside `player.py`.
+
+### 6.4 Volume scaling consistency
+
+API uses 0-100 everywhere. UPnP devices: passed as-is (0-100). Cast: translate to 0.0-1.0 in device layer (`/ 100.0`). Cast → API: reverse translate (`* 100`). Single source of truth in protocol definition.
+
+### 6.5 Race: track change while loading
+
+Cast has an async load phase (~1-3s). If user skips track while previous track is loading, `pychromecast` / `RemoteMediaClient` handles the abort and re-queue internally. Add a `_loading` flag in monitors to suppress auto-advance during transitions (same pattern as `_mark_monitor_starting` in existing UPnP code).
+
+### 6.6 Long-lived stream tokens
+
+Phase 1's 24h Cast stream tokens are a weak point. Tokens are track-bound (`track_id` claim) so scope is limited, but a leaked URL plays one track for one day. Mitigations:
+- Prefer duration-based TTL capped by config
+- If true revocation is needed, add a token nonce/version store; reissuing a
+  stateless JWT alone does not make old URLs stale
+- Consider IP-agnostic design (no client IP binding — Cast device IP is unpredictable)
+- Future: token bound to Cast device UUID (picked up from Cast protocol handshake)
+
+### 6.7 Hardening test coverage
+
+- Reconnect tests:
+  - backend marks device unavailable after disconnect
+  - backend recovers after rediscovery
+  - active renderer state remains readable while unavailable
+- Race tests:
+  - skip during Cast load does not auto-advance wrong track
+  - duplicate ended/status callbacks do not double-advance
+  - pause near end of track does not falsely advance
+  - renderer switch stops old backend before new backend starts
+- Token tests:
+  - duration-based Cast token TTL if implemented
+  - expired Cast token returns 401
+  - wrong-track token returns 401
+  - nonce/version revocation if implemented
+- Group tests:
+  - Cast group volume/status mapping
+  - group disconnect marks group unavailable without marking unrelated devices dead
+- Regression suite:
+  - server API tests
+  - stream/auth tests
+  - web component tests
+  - Android unit tests
+
+### 6.8 Delivery gate
+
+- Known disconnect/race/token cases covered by automated tests
+- Manual smoke across local, UPnP, server-Cast, and Android device-Cast completed
+- Documentation updated for Docker host networking, codec support, token TTL, and
+  Android Play Services limitation
+
+---
+
+## Phase Ordering & Dependencies
+
+```
+Phase 0 (Baseline) ──required──▶ Phase 1 (Foundation)
+                                  │
+                                  ├──required──▶ Phase 2 (Server Cast)
+                                  │                   │
+                                  │                   └──required──▶ Phase 4 (Web UI)
+                                  │
+                                  └──required──▶ Phase 3 (Device Cast)
+
+Phase 6 (Hardening) follows Phase 2+3+4.
+
+Phase 5 (Future Backend Shapes) is design-only for v1 and should not block Cast.
+```
+
+**Recommended build order:** 0 → 1 → 2 → 4 → 3 → 6
+
+Phase 1 is the riskiest because it touches every playback endpoint. Phase 2 is
+the highest-value deliverable. Phase 4 should follow Phase 2 so server-driven
+Cast is usable from web before Android device-direct Cast starts.
+
+Minimum phase gates:
+
+- Phase 0: `./test.sh tests/api/test_player.py tests/api/test_stream.py`
+- Phase 1: `./test.sh`, `cd web && npm run check && npm test`, `android/test.sh`
+- Phase 2: `./test.sh`, plus manual server-Cast smoke on real hardware
+- Phase 4: `cd web && npm run check && npm test && npm run build`
+- Phase 3: `android/test.sh`, plus manual Android-to-Cast smoke on real hardware
+- Phase 6: full regression gates plus all manual smoke paths
+
+---
+
+## Open Design Decisions
+
+1. **Stream token TTL for Cast** — 24h is simple but long. Per-track tokens that live as long as the track duration * 2 (to cover pauses) would be tighter. Needs `duration_seconds` at token creation time.
+
+2. **Server Cast in Docker** — Docker `network_mode: host` is already required for UPnP multicast. Same for Cast mDNS. Document this.
+
+3. **Android Cast without Play Services** — Cast SDK requires Google Play Services. LineageOS / de-Googled devices can't use device-direct Cast (server-driven still works). Accept this limitation.
+
+4. **Cast firmware compatibility** — `pychromecast` supports Cast protocol v2 (Chromecast gen 1+). Google Nest / Chromecast Audio / Google Home all work. Very old (2013) gen 1 Chromecast limited to v1 — test before claiming support.
+
+5. **Auth on artwork URLs** — Cast receiver fetches artwork URL directly. Currently `/art/{sha1}.jpg` has no auth requirement. Confirm this stays true and document.

--- a/plan-chromecast.md
+++ b/plan-chromecast.md
@@ -194,10 +194,35 @@ Delivery strategy: ship this in small slices with UPnP behavior preserved at
 each step. Do not add Chromecast control until UPnP works through the new
 orchestrator.
 
+### Phase 1 implementation status
+
+Implemented in this branch:
+
+- Protocol-neutral renderer contracts, registry, persistence helpers, and
+  orchestrator foundation
+- UPnP adapter wrapping the existing `UPnPManager`
+- `renderer.kind`, `renderer.native_id`, `renderer.renderer_id`, Cast metadata,
+  availability, and `client_session.active_renderer_id` migration/backfill
+- Backwards-compatible renderer selection: old `udn` input and
+  `active_renderer_udn` storage still work
+- `/api/renderers`, `/api/player/renderer`, and `/api/player/state` expose
+  canonical `renderer_id`/`kind` fields
+- Player endpoints route playback controls through the orchestrator instead of
+  importing `UPnPManager` directly
+- Renderer-kind stream token policy hook: default streams remain 300s; Cast-kind
+  stream URLs use duration-aware TTL capped by `CAST_STREAM_TOKEN_TTL_SECONDS`
+- Server verification passed: `./test.sh` -> 335 passed, 1 skipped
+
+Deferred to Phase 2/3:
+
+- Real Chromecast/AirPlay backends
+- Full callback-driven status pipeline for event-capable renderers
+- Android UI migration to prefer `renderer_id` everywhere
+
 ### 1.1 DB migration
 
 ```
-migrations/029_renderer_kind.sql
+migrations/029_renderer_backend.sql
 ```
 
 - Add `kind TEXT DEFAULT 'upnp'` to `renderer` table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "croniter",
     "python-jose[cryptography]",
     "slowapi",
+    "pychromecast>=14.0.0",
+    "zeroconf>=0.130.0",
 ]
 
 

--- a/tests/api/test_player_phase0_api.py
+++ b/tests/api/test_player_phase0_api.py
@@ -1,0 +1,108 @@
+import pytest
+from httpx import AsyncClient
+
+from tests.helpers.fake_renderers import FakeUpnpManager
+
+
+@pytest.fixture
+async def phase0_tracks(db):
+    await db.execute(
+        """
+        INSERT INTO track (id, path, title, artist, album, duration_seconds)
+        VALUES
+            (501, '/music/phase0-a.flac', 'Phase A', 'Artist', 'Album', 120),
+            (502, '/music/phase0-b.mp3', 'Phase B', 'Artist', 'Album', 180)
+        """
+    )
+
+
+@pytest.fixture
+async def selected_remote_renderer(db):
+    udn = "uuid:phase0-upnp"
+    await db.execute(
+        """
+        INSERT INTO client_session (client_id, active_renderer_udn, last_seen_at)
+        VALUES ('phase0-client', $1, NOW())
+        """,
+        udn,
+    )
+    return udn
+
+
+@pytest.mark.asyncio
+async def test_phase0_remote_transport_controls_call_upnp_manager(
+    auth_client: AsyncClient,
+    db,
+    monkeypatch,
+    selected_remote_renderer,
+):
+    fake_upnp = FakeUpnpManager()
+    import app.api.player as player_api
+
+    monkeypatch.setattr(player_api, "upnp", fake_upnp)
+    headers = {"X-Jamarr-Client-Id": "phase0-client"}
+
+    pause = await auth_client.post("/api/player/pause", headers=headers)
+    resume = await auth_client.post("/api/player/resume", headers=headers)
+    seek = await auth_client.post("/api/player/seek", json={"seconds": 42.5}, headers=headers)
+    volume = await auth_client.post("/api/player/volume", json={"percent": 77}, headers=headers)
+
+    assert pause.status_code == 200, pause.text
+    assert resume.status_code == 200, resume.text
+    assert seek.status_code == 200, seek.text
+    assert volume.status_code == 200, volume.text
+
+    assert [cmd.name for cmd in fake_upnp.commands] == [
+        "set_renderer",
+        "pause",
+        "set_renderer",
+        "resume",
+        "set_renderer",
+        "seek",
+        "set_renderer",
+        "set_volume",
+    ]
+    assert fake_upnp.commands[0].args == (selected_remote_renderer,)
+    assert fake_upnp.commands[5].args == (42.5,)
+    assert fake_upnp.commands[7].args == (77,)
+
+    state = await auth_client.get("/api/player/state", headers=headers)
+    assert state.status_code == 200
+    assert state.json()["volume"] == 77
+
+
+@pytest.mark.asyncio
+async def test_phase0_remote_play_route_sets_base_url_and_starts_monitor(
+    auth_client: AsyncClient,
+    db,
+    monkeypatch,
+    phase0_tracks,
+    selected_remote_renderer,
+):
+    fake_upnp = FakeUpnpManager()
+    import app.api.player as player_api
+
+    monkeypatch.setattr(player_api, "upnp", fake_upnp)
+    monkeypatch.setattr(player_api, "start_monitor_task", lambda udn: None)
+    headers = {"X-Jamarr-Client-Id": "phase0-client"}
+
+    response = await auth_client.post(
+        "/api/player/play",
+        json={"track_id": 501},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "streaming_started", "renderer": selected_remote_renderer}
+    assert [cmd.name for cmd in fake_upnp.commands] == ["set_renderer", "play_track"]
+    assert fake_upnp.commands[0].args == (selected_remote_renderer,)
+    assert fake_upnp.commands[1].args[0] == 501
+    assert fake_upnp.commands[1].args[1] == "/music/phase0-a.flac"
+    assert fake_upnp.base_url == "http://127.0.0.1:8111"
+
+    state = await auth_client.get("/api/player/state", headers=headers)
+    data = state.json()
+    assert data["renderer"] == selected_remote_renderer
+    assert data["queue"][0]["id"] == 501
+    assert data["is_playing"] is True
+    assert data["transport_state"] == "PLAYING"

--- a/tests/api/test_player_phase0_api.py
+++ b/tests/api/test_player_phase0_api.py
@@ -38,8 +38,15 @@ async def test_phase0_remote_transport_controls_call_upnp_manager(
 ):
     fake_upnp = FakeUpnpManager()
     import app.api.player as player_api
+    import app.services.renderer.orchestrator as orchestrator_module
+    from app.services.renderer.upnp_backend import UpnpRendererBackend
 
-    monkeypatch.setattr(player_api, "upnp", fake_upnp)
+    monkeypatch.setitem(
+        player_api.renderer_orchestrator.registry.backends,
+        "upnp",
+        UpnpRendererBackend(fake_upnp),
+    )
+    monkeypatch.setattr(orchestrator_module, "start_monitor_task", lambda udn: None)
     headers = {"X-Jamarr-Client-Id": "phase0-client"}
 
     pause = await auth_client.post("/api/player/pause", headers=headers)
@@ -81,9 +88,15 @@ async def test_phase0_remote_play_route_sets_base_url_and_starts_monitor(
 ):
     fake_upnp = FakeUpnpManager()
     import app.api.player as player_api
+    import app.services.renderer.orchestrator as orchestrator_module
+    from app.services.renderer.upnp_backend import UpnpRendererBackend
 
-    monkeypatch.setattr(player_api, "upnp", fake_upnp)
-    monkeypatch.setattr(player_api, "start_monitor_task", lambda udn: None)
+    monkeypatch.setitem(
+        player_api.renderer_orchestrator.registry.backends,
+        "upnp",
+        UpnpRendererBackend(fake_upnp),
+    )
+    monkeypatch.setattr(orchestrator_module, "start_monitor_task", lambda udn: None)
     headers = {"X-Jamarr-Client-Id": "phase0-client"}
 
     response = await auth_client.post(

--- a/tests/api/test_renderer_phase1_api.py
+++ b/tests/api/test_renderer_phase1_api.py
@@ -1,0 +1,58 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_phase1_player_state_includes_renderer_id_fields(auth_client: AsyncClient):
+    response = await auth_client.get(
+        "/api/player/state",
+        headers={"X-Jamarr-Client-Id": "phase1-client"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["renderer"] == "local:phase1-client"
+    assert data["renderer_id"] == "local:phase1-client"
+    assert data["renderer_kind"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_phase1_set_renderer_accepts_renderer_id_and_keeps_udn_compat(
+    auth_client: AsyncClient,
+    db,
+):
+    response = await auth_client.post(
+        "/api/player/renderer",
+        json={"renderer_id": "upnp:uuid:phase1"},
+        headers={"X-Jamarr-Client-Id": "phase1-client"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["active"] == "uuid:phase1"
+    assert response.json()["renderer_id"] == "upnp:uuid:phase1"
+
+    row = await db.fetchrow(
+        """
+        SELECT active_renderer_udn, active_renderer_id
+        FROM client_session
+        WHERE client_id = 'phase1-client'
+        """
+    )
+    assert row["active_renderer_udn"] == "uuid:phase1"
+    assert row["active_renderer_id"] == "upnp:uuid:phase1"
+
+
+@pytest.mark.asyncio
+async def test_phase1_renderers_include_unified_fields(auth_client: AsyncClient):
+    response = await auth_client.get(
+        "/api/renderers",
+        headers={"X-Jamarr-Client-Id": "phase1-client"},
+    )
+
+    assert response.status_code == 200
+    local = response.json()[0]
+    assert local["renderer_id"] == "local:phase1-client"
+    assert local["kind"] == "local"
+    assert local["native_id"] == "phase1-client"
+    assert local["udn"] == "local:phase1-client"
+    assert local["type"] == "local"

--- a/tests/api/test_renderer_phase2_api.py
+++ b/tests/api/test_renderer_phase2_api.py
@@ -1,0 +1,212 @@
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from httpx import AsyncClient
+
+from app.services.renderer.cast_backend import CastRendererBackend
+from tests.unit.test_renderer_phase2_cast import FakeBrowser, FakeCast
+
+
+@pytest.fixture
+async def phase2_cast_track(db):
+    await db.execute(
+        """
+        INSERT INTO track (id, path, title, artist, album, duration_seconds)
+        VALUES (901, '/music/phase2-cast.flac', 'Cast Song', 'Cast Artist', 'Cast Album', 240)
+        """
+    )
+
+
+@pytest.fixture
+async def selected_cast_renderer(db):
+    renderer_id = "cast:11111111-1111-1111-1111-111111111111"
+    await db.execute(
+        """
+        INSERT INTO client_session (
+            client_id, active_renderer_udn, active_renderer_id, last_seen_at
+        )
+        VALUES ('phase2-client', $1, $1, NOW())
+        """,
+        renderer_id,
+    )
+    return renderer_id
+
+
+@pytest.fixture
+async def fake_cast_backend(monkeypatch):
+    cast = FakeCast()
+    backend = CastRendererBackend(chromecast_getter=lambda **_: ([cast], FakeBrowser()))
+    await backend.discover(refresh=True)
+    monitor_starts = []
+
+    import app.api.player as player_api
+    import app.services.renderer.orchestrator as orchestrator_module
+
+    monkeypatch.setitem(player_api.renderer_orchestrator.registry.backends, "cast", backend)
+    monkeypatch.setattr(player_api, "start_monitor_task", lambda renderer: monitor_starts.append(renderer))
+    monkeypatch.setattr(orchestrator_module, "start_monitor_task", lambda renderer: monitor_starts.append(renderer))
+    return backend, cast, monitor_starts
+
+
+@pytest.mark.asyncio
+async def test_phase2_renderers_can_return_cast_devices(
+    auth_client: AsyncClient,
+    fake_cast_backend,
+):
+    response = await auth_client.get(
+        "/api/renderers",
+        headers={"X-Jamarr-Client-Id": "phase2-client"},
+    )
+
+    assert response.status_code == 200, response.text
+    cast_rows = [row for row in response.json() if row["kind"] == "cast"]
+    assert cast_rows
+    assert cast_rows[0]["renderer_id"] == "cast:11111111-1111-1111-1111-111111111111"
+    assert cast_rows[0]["cast_type"] == "audio"
+    assert cast_rows[0]["capabilities"]["supports_events"] is True
+
+
+@pytest.mark.asyncio
+async def test_phase2_player_controls_route_to_cast_backend(
+    auth_client: AsyncClient,
+    phase2_cast_track,
+    selected_cast_renderer,
+    fake_cast_backend,
+):
+    _, cast, monitor_starts = fake_cast_backend
+    headers = {"X-Jamarr-Client-Id": "phase2-client"}
+
+    play = await auth_client.post(
+        "/api/player/play",
+        json={"track_id": 901},
+        headers=headers,
+    )
+    play_again = await auth_client.post(
+        "/api/player/play",
+        json={"track_id": 901},
+        headers=headers,
+    )
+    pause = await auth_client.post("/api/player/pause", headers=headers)
+    resume = await auth_client.post("/api/player/resume", headers=headers)
+    seek = await auth_client.post("/api/player/seek", json={"seconds": 22}, headers=headers)
+    volume = await auth_client.post("/api/player/volume", json={"percent": 44}, headers=headers)
+
+    assert play.status_code == 200, play.text
+    assert play.json() == {"status": "streaming_started", "renderer": selected_cast_renderer}
+    assert play_again.status_code == 200, play_again.text
+    assert play_again.json() == {"status": "already_playing", "renderer": selected_cast_renderer}
+    assert pause.status_code == 200, pause.text
+    assert resume.status_code == 200, resume.text
+    assert seek.status_code == 200, seek.text
+    assert volume.status_code == 200, volume.text
+
+    assert any(call[0] == "start_app" for call in cast.calls)
+    assert ("pause", (), {}) in cast.media_controller.calls
+    assert ("play", (), {}) in cast.media_controller.calls
+    assert ("seek", (22.0,), {}) in cast.media_controller.calls
+    assert ("set_volume", 0.44) in cast.calls
+    assert monitor_starts == []
+
+    state = await auth_client.get("/api/player/state", headers=headers)
+    assert state.status_code == 200
+    assert state.json()["renderer_id"] == selected_cast_renderer
+    assert state.json()["renderer_kind"] == "cast"
+    assert state.json()["position_seconds"] == 12
+    assert state.json()["volume"] == 40
+    assert monitor_starts == []
+
+
+@pytest.mark.asyncio
+async def test_phase2_clear_queue_closes_cast_session(
+    auth_client: AsyncClient,
+    phase2_cast_track,
+    selected_cast_renderer,
+    fake_cast_backend,
+):
+    _, cast, monitor_starts = fake_cast_backend
+    headers = {"X-Jamarr-Client-Id": "phase2-client"}
+
+    play = await auth_client.post(
+        "/api/player/play",
+        json={"track_id": 901},
+        headers=headers,
+    )
+    clear = await auth_client.post("/api/player/queue/clear", headers=headers)
+
+    assert play.status_code == 200, play.text
+    assert clear.status_code == 200, clear.text
+    assert ("stop", (), {}) in cast.media_controller.calls
+    assert ("quit_app", 10) in cast.calls
+    assert monitor_starts == []
+
+
+@pytest.mark.asyncio
+async def test_phase2_switching_away_from_cast_closes_previous_session(
+    auth_client: AsyncClient,
+    selected_cast_renderer,
+    fake_cast_backend,
+):
+    _, cast, monitor_starts = fake_cast_backend
+    headers = {"X-Jamarr-Client-Id": "phase2-client"}
+
+    response = await auth_client.post(
+        "/api/player/renderer",
+        json={"renderer_id": "local:phase2-client"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["renderer_id"] == "local:phase2-client"
+    assert ("stop", (), {}) in cast.media_controller.calls
+    assert ("quit_app", 10) in cast.calls
+    assert monitor_starts == []
+
+
+@pytest.mark.asyncio
+async def test_phase2_cast_progress_logs_history_and_scrobbles(
+    auth_client: AsyncClient,
+    db,
+    phase2_cast_track,
+    selected_cast_renderer,
+    fake_cast_backend,
+):
+    _, cast, monitor_starts = fake_cast_backend
+    headers = {"X-Jamarr-Client-Id": "phase2-client"}
+    user = await db.fetchrow('SELECT id FROM "user" WHERE username = $1', "testuser")
+    await db.execute(
+        """
+        UPDATE "user"
+        SET lastfm_username = $1,
+            lastfm_session_key = $2,
+            lastfm_enabled = TRUE
+        WHERE id = $3
+        """,
+        "testuser_lastfm",
+        "test_session_key",
+        user["id"],
+    )
+
+    play = await auth_client.post(
+        "/api/player/play",
+        json={"track_id": 901},
+        headers=headers,
+    )
+    cast.media_controller.status.adjusted_current_time = 35
+    cast.media_controller.status.current_time = 35
+
+    with patch("app.lastfm.scrobble_track", new_callable=AsyncMock) as mock_scrobble:
+        state = await auth_client.get("/api/player/state", headers=headers)
+        await asyncio.sleep(0.1)
+
+    assert play.status_code == 200, play.text
+    assert state.status_code == 200, state.text
+    assert state.json()["queue"][0]["logged"] is True
+    rows = await db.fetch("SELECT track_id, client_id, user_id FROM playback_history WHERE track_id = 901")
+    assert len(rows) == 1
+    assert rows[0]["client_id"] == selected_cast_renderer
+    assert rows[0]["user_id"] == user["id"]
+    assert mock_scrobble.called
+    assert mock_scrobble.call_args.kwargs["session_key"] == "test_session_key"
+    assert mock_scrobble.call_args.kwargs["track_info"]["track"] == "Cast Song"
+    assert monitor_starts == []

--- a/tests/api/test_stream.py
+++ b/tests/api/test_stream.py
@@ -2,6 +2,10 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from app.main import app
 import os
+from datetime import datetime, timezone
+from urllib.parse import parse_qs, urlparse
+
+from jose import jwt
 
 @pytest.fixture
 async def stream_data(db):
@@ -97,3 +101,15 @@ async def test_stream_url_token_access(client: AsyncClient, auth_client: AsyncCl
 
     token_response = await client.get(data["url"])
     assert token_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stream_url_cast_token_uses_renderer_policy(auth_client: AsyncClient, db, stream_data):
+    response = await auth_client.get("/api/stream-url/999?renderer_kind=cast")
+
+    assert response.status_code == 200
+    token = parse_qs(urlparse(response.json()["url"]).query)["token"][0]
+    claims = jwt.get_unverified_claims(token)
+    issued_at = datetime.fromtimestamp(claims["iat"], tz=timezone.utc)
+    expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+    assert (expires_at - issued_at).total_seconds() == 1800

--- a/tests/auth/test_migration_029.py
+++ b/tests/auth/test_migration_029.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from migrations.apply_migrations import _split_statements
+
+
+def test_migration_029_splits_cleanly():
+    migration = Path("migrations/029_renderer_backend.sql")
+    statements = _split_statements(migration.read_text())
+
+    assert len(statements) >= 5
+    assert any("ALTER TABLE renderer" in stmt for stmt in statements)
+    assert any("active_renderer_id" in stmt for stmt in statements)
+
+
+async def test_migration_029_columns_exist(db):
+    renderer_cols = await db.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = 'renderer'
+          AND column_name = ANY($1::text[])
+        """,
+        [
+            "kind",
+            "native_id",
+            "renderer_id",
+            "cast_uuid",
+            "cast_type",
+            "last_discovered_by",
+            "available",
+            "enabled_by_default",
+            "renderer_metadata",
+        ],
+    )
+    session_cols = await db.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = 'client_session'
+          AND column_name = 'active_renderer_id'
+        """
+    )
+
+    assert {row["column_name"] for row in renderer_cols} == {
+        "kind",
+        "native_id",
+        "renderer_id",
+        "cast_uuid",
+        "cast_type",
+        "last_discovered_by",
+        "available",
+        "enabled_by_default",
+        "renderer_metadata",
+    }
+    assert len(session_cols) == 1
+
+
+async def test_migration_029_renderer_id_has_upsert_compatible_unique_constraint(db):
+    rows = await db.fetch(
+        """
+        SELECT c.conname
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_attribute a
+          ON a.attrelid = t.oid
+         AND a.attnum = ANY(c.conkey)
+        WHERE t.relname = 'renderer'
+          AND c.contype = 'u'
+          AND a.attname = 'renderer_id'
+        """
+    )
+
+    assert rows

--- a/tests/auth/test_stream_token_phase0.py
+++ b/tests/auth/test_stream_token_phase0.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from jose import jwt
+
+
+def test_phase0_stream_token_default_ttl_is_300_seconds():
+    from app.auth_tokens import create_stream_token
+
+    token = create_stream_token(track_id=901, user_id=42)
+    claims = jwt.get_unverified_claims(token)
+
+    issued_at = datetime.fromtimestamp(claims["iat"], tz=timezone.utc)
+    expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+
+    assert (expires_at - issued_at).total_seconds() == 300
+    assert claims["sub"] == "stream"
+    assert claims["track_id"] == 901
+    assert claims["user_id"] == 42
+    assert claims["aud"] == "jamarr-stream"

--- a/tests/helpers/fake_renderers.py
+++ b/tests/helpers/fake_renderers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FakeRendererStatus:
+    renderer_id: str
+    state: str
+    position_seconds: float = 0
+    duration_seconds: float | None = None
+    volume_percent: int | None = None
+    ended: bool = False
+
+
+@dataclass
+class FakeRendererCommand:
+    name: str
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeUpnpManager:
+    """Small recorder for current UPnP-manager-shaped tests."""
+
+    def __init__(self) -> None:
+        self.commands: list[FakeRendererCommand] = []
+        self.local_ip = "127.0.0.1"
+        self.base_url = "http://127.0.0.1:8111"
+        self.renderers: dict[str, dict[str, Any]] = {}
+        self.active_renderer: str | None = None
+        self.is_scanning_subnet = False
+        self.scan_msg = ""
+        self.scan_progress = 0
+        self.debug_log: list[str] = []
+
+    async def discover(self) -> None:
+        self.commands.append(FakeRendererCommand("discover"))
+
+    async def scan_subnet(self) -> None:
+        self.commands.append(FakeRendererCommand("scan_subnet"))
+
+    async def get_renderers(self) -> list[dict[str, Any]]:
+        self.commands.append(FakeRendererCommand("get_renderers"))
+        return list(self.renderers.values())
+
+    async def set_renderer(self, udn: str) -> None:
+        self.active_renderer = udn
+        self.commands.append(FakeRendererCommand("set_renderer", (udn,)))
+
+    async def play_track(
+        self,
+        track_id: int,
+        track_path: str | None,
+        metadata: dict[str, Any],
+        username: str | None = None,
+    ) -> dict[str, Any]:
+        self.commands.append(
+            FakeRendererCommand(
+                "play_track",
+                (track_id, track_path, metadata),
+                {"username": username},
+            )
+        )
+        return {"status": "ok"}
+
+    async def pause(self) -> None:
+        self.commands.append(FakeRendererCommand("pause"))
+
+    async def resume(self) -> None:
+        self.commands.append(FakeRendererCommand("resume"))
+
+    async def seek(self, seconds: float) -> None:
+        self.commands.append(FakeRendererCommand("seek", (seconds,)))
+
+    async def set_volume(self, percent: int) -> None:
+        self.commands.append(FakeRendererCommand("set_volume", (percent,)))
+
+
+def status_playing(renderer_id: str, position: float = 0) -> FakeRendererStatus:
+    return FakeRendererStatus(renderer_id=renderer_id, state="PLAYING", position_seconds=position)
+
+
+def status_paused(renderer_id: str, position: float = 0) -> FakeRendererStatus:
+    return FakeRendererStatus(renderer_id=renderer_id, state="PAUSED", position_seconds=position)
+
+
+def status_ended(renderer_id: str) -> FakeRendererStatus:
+    return FakeRendererStatus(renderer_id=renderer_id, state="IDLE", ended=True)

--- a/tests/unit/test_player_phase0_unit.py
+++ b/tests/unit/test_player_phase0_unit.py
@@ -1,0 +1,105 @@
+import pytest
+
+from tests.helpers.fake_renderers import FakeUpnpManager, status_ended, status_paused, status_playing
+
+
+@pytest.mark.asyncio
+async def test_phase0_play_next_track_internal_advances_queue(db, monkeypatch):
+    from app.services.player import queue as queue_module
+    from app.services.player.globals import last_track_start_time
+    from app.services.player.state import update_renderer_state_db, get_renderer_state_db
+
+    fake_upnp = FakeUpnpManager()
+    monkeypatch.setattr(queue_module.UPnPManager, "get_instance", lambda: fake_upnp)
+
+    udn = "uuid:phase0-upnp"
+    state = {
+        "queue": [
+            {
+                "id": 601,
+                "title": "First",
+                "artist": "Artist",
+                "album": "Album",
+                "path": "/music/first.flac",
+                "duration_seconds": 100,
+            },
+            {
+                "id": 602,
+                "title": "Second",
+                "artist": "Artist",
+                "album": "Album",
+                "path": "/music/second.mp3",
+                "duration_seconds": 100,
+            },
+        ],
+        "current_index": 0,
+        "position_seconds": 72,
+        "is_playing": True,
+        "transport_state": "PLAYING",
+        "volume": 30,
+    }
+    await update_renderer_state_db(db, udn, state)
+
+    await queue_module.play_next_track_internal(udn)
+
+    assert [cmd.name for cmd in fake_upnp.commands] == ["set_renderer", "play_track"]
+    assert fake_upnp.commands[0].args == (udn,)
+    assert fake_upnp.commands[1].args[0] == 602
+    assert fake_upnp.commands[1].args[1] == "/music/second.mp3"
+    assert fake_upnp.commands[1].args[2]["mime"] == "audio/mpeg"
+    assert fake_upnp.base_url == "http://127.0.0.1:8111"
+    assert udn in last_track_start_time
+
+    updated = await get_renderer_state_db(db, udn)
+    assert updated["current_index"] == 1
+    assert updated["position_seconds"] == 0
+    assert updated["is_playing"] is True
+
+
+@pytest.mark.asyncio
+async def test_phase0_play_next_track_internal_marks_end_of_queue(db, monkeypatch):
+    from app.services.player import queue as queue_module
+    from app.services.player.state import update_renderer_state_db, get_renderer_state_db
+
+    fake_upnp = FakeUpnpManager()
+    monkeypatch.setattr(queue_module.UPnPManager, "get_instance", lambda: fake_upnp)
+
+    udn = "uuid:phase0-upnp"
+    await update_renderer_state_db(
+        db,
+        udn,
+        {
+            "queue": [
+                {
+                    "id": 701,
+                    "title": "Only",
+                    "artist": "Artist",
+                    "album": "Album",
+                    "path": "/music/only.flac",
+                    "duration_seconds": 100,
+                }
+            ],
+            "current_index": 0,
+            "position_seconds": 98,
+            "is_playing": True,
+            "transport_state": "PLAYING",
+            "volume": None,
+        },
+    )
+
+    await queue_module.play_next_track_internal(udn)
+
+    assert fake_upnp.commands == []
+    updated = await get_renderer_state_db(db, udn)
+    assert updated["current_index"] == 0
+    assert updated["position_seconds"] == 0
+    assert updated["is_playing"] is False
+
+
+def test_phase0_fake_status_helpers_cover_expected_states():
+    assert status_playing("upnp:one", 12).state == "PLAYING"
+    assert status_playing("upnp:one", 12).position_seconds == 12
+    assert status_paused("upnp:one", 8).state == "PAUSED"
+    ended = status_ended("upnp:one")
+    assert ended.state == "IDLE"
+    assert ended.ended is True

--- a/tests/unit/test_renderer_phase1.py
+++ b/tests/unit/test_renderer_phase1.py
@@ -1,0 +1,92 @@
+import pytest
+
+from app.services.renderer.contracts import (
+    RendererCapabilities,
+    RendererDevice,
+    make_renderer_id,
+    split_renderer_id,
+)
+from app.services.renderer.registry import RendererRegistry
+from app.services.renderer.token_policy import stream_token_ttl_seconds
+from app.services.renderer.upnp_backend import UpnpRendererBackend
+from tests.helpers.fake_renderers import FakeUpnpManager
+
+
+def test_phase1_renderer_id_helpers_treat_legacy_ids_as_upnp():
+    assert make_renderer_id("upnp", "uuid:test") == "upnp:uuid:test"
+    assert make_renderer_id("cast", "cast-id") == "cast:cast-id"
+    assert split_renderer_id("uuid:test") == ("upnp", "uuid:test")
+    assert split_renderer_id("cast:cast-id") == ("cast", "cast-id")
+
+
+def test_phase1_renderer_device_api_shape_includes_backcompat_fields():
+    device = RendererDevice(
+        renderer_id="upnp:uuid:test",
+        kind="upnp",
+        native_id="uuid:test",
+        udn="uuid:test",
+        name="Living Room",
+        capabilities=RendererCapabilities(supported_mime_types={"audio/flac"}),
+    )
+
+    data = device.as_api_dict()
+
+    assert data["renderer_id"] == "upnp:uuid:test"
+    assert data["kind"] == "upnp"
+    assert data["native_id"] == "uuid:test"
+    assert data["udn"] == "uuid:test"
+    assert data["type"] == "upnp"
+    assert data["capabilities"]["supported_mime_types"] == ["audio/flac"]
+
+
+def test_phase1_registry_maps_legacy_state_keys():
+    registry = RendererRegistry()
+
+    assert registry.normalize_renderer_id("uuid:test") == "upnp:uuid:test"
+    assert registry.normalize_renderer_id("upnp:uuid:test") == "upnp:uuid:test"
+    assert registry.legacy_or_renderer_id_to_state_key("upnp:uuid:test") == "uuid:test"
+    assert registry.state_key_to_renderer_id("uuid:test") == "upnp:uuid:test"
+    assert registry.state_key_to_renderer_id("local:abc") == "local:abc"
+    assert registry.state_key_to_renderer_id("cast:abc") == "cast:abc"
+
+
+def test_phase1_cast_stream_token_ttl_policy(monkeypatch):
+    monkeypatch.setenv("CAST_STREAM_TOKEN_TTL_SECONDS", "7200")
+
+    assert stream_token_ttl_seconds("upnp", 3600) is None
+    assert stream_token_ttl_seconds("cast", 100) == 1800
+    assert stream_token_ttl_seconds("cast", 4000) == 7200
+    assert stream_token_ttl_seconds("cast", None) == 7200
+
+
+@pytest.mark.asyncio
+async def test_phase1_upnp_backend_lists_normalized_devices():
+    fake = FakeUpnpManager()
+    fake.renderers = {
+        "uuid:test": {
+            "udn": "uuid:test",
+            "friendly_name": "Kitchen",
+            "ip": "192.0.2.10",
+            "manufacturer": "Test",
+            "model_name": "Model",
+            "supported_mime_types": "audio/flac,audio/mpeg",
+        }
+    }
+    backend = UpnpRendererBackend(fake)
+
+    devices = await backend.list_devices()
+
+    assert len(devices) == 1
+    device = devices[0]
+    assert device.renderer_id == "upnp:uuid:test"
+    assert device.native_id == "uuid:test"
+    assert device.name == "Kitchen"
+    assert device.capabilities.supported_mime_types == {"audio/flac", "audio/mpeg"}
+
+
+def test_phase1_upnp_transport_mapping():
+    assert UpnpRendererBackend.normalize_transport_state("PLAYING") == "PLAYING"
+    assert UpnpRendererBackend.normalize_transport_state("TRANSITIONING") == "PLAYING"
+    assert UpnpRendererBackend.normalize_transport_state("PAUSED_PLAYBACK") == "PAUSED"
+    assert UpnpRendererBackend.normalize_transport_state("STOPPED") == "IDLE"
+    assert UpnpRendererBackend.normalize_transport_state("VENDOR_DEFINED") == "UNKNOWN"

--- a/tests/unit/test_renderer_phase1.py
+++ b/tests/unit/test_renderer_phase1.py
@@ -26,6 +26,10 @@ def test_phase1_renderer_device_api_shape_includes_backcompat_fields():
         native_id="uuid:test",
         udn="uuid:test",
         name="Living Room",
+        icon_url="/art/renderer/uuid:test",
+        icon_mime="image/png",
+        icon_width=64,
+        icon_height=64,
         capabilities=RendererCapabilities(supported_mime_types={"audio/flac"}),
     )
 
@@ -36,6 +40,10 @@ def test_phase1_renderer_device_api_shape_includes_backcompat_fields():
     assert data["native_id"] == "uuid:test"
     assert data["udn"] == "uuid:test"
     assert data["type"] == "upnp"
+    assert data["icon_url"] == "/art/renderer/uuid:test"
+    assert data["icon_mime"] == "image/png"
+    assert data["icon_width"] == 64
+    assert data["icon_height"] == 64
     assert data["capabilities"]["supported_mime_types"] == ["audio/flac"]
 
 
@@ -69,6 +77,12 @@ async def test_phase1_upnp_backend_lists_normalized_devices():
             "ip": "192.0.2.10",
             "manufacturer": "Test",
             "model_name": "Model",
+            "model_number": "One",
+            "device_type": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "icon_url": "/art/renderer/uuid:test",
+            "icon_mime": "image/png",
+            "icon_width": 64,
+            "icon_height": 64,
             "supported_mime_types": "audio/flac,audio/mpeg",
         }
     }
@@ -81,6 +95,12 @@ async def test_phase1_upnp_backend_lists_normalized_devices():
     assert device.renderer_id == "upnp:uuid:test"
     assert device.native_id == "uuid:test"
     assert device.name == "Kitchen"
+    assert device.icon_url == "/art/renderer/uuid:test"
+    assert device.icon_mime == "image/png"
+    assert device.icon_width == 64
+    assert device.icon_height == 64
+    assert device.model_number == "One"
+    assert device.device_type == "urn:schemas-upnp-org:device:MediaRenderer:1"
     assert device.capabilities.supported_mime_types == {"audio/flac", "audio/mpeg"}
 
 

--- a/tests/unit/test_renderer_phase2_cast.py
+++ b/tests/unit/test_renderer_phase2_cast.py
@@ -1,0 +1,244 @@
+import asyncio
+import time
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from app.services.renderer.cast_backend import CastRendererBackend
+from app.services.renderer.contracts import PlaybackContext
+
+
+class FakeBrowser:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop_discovery(self) -> None:
+        self.stopped = True
+
+
+class FakeMediaController:
+    def __init__(self) -> None:
+        self.calls = []
+        self.listeners = []
+        self.status = SimpleNamespace(
+            player_state="PLAYING",
+            adjusted_current_time=12,
+            duration=120,
+            volume_level=0.4,
+            volume_muted=False,
+            content_id="http://media",
+        )
+
+    def play_media(self, *args, **kwargs) -> None:
+        self.calls.append(("play_media", args, kwargs))
+
+    def pause(self) -> None:
+        self.calls.append(("pause", (), {}))
+
+    def play(self) -> None:
+        self.calls.append(("play", (), {}))
+
+    def stop(self) -> None:
+        self.calls.append(("stop", (), {}))
+
+    def seek(self, seconds) -> None:
+        self.calls.append(("seek", (seconds,), {}))
+
+    def register_status_listener(self, listener) -> None:
+        self.listeners.append(listener)
+
+    def update_status(self, callback_function=None) -> None:
+        self.calls.append(("update_status", (), {}))
+        if callback_function:
+            callback_function(True, {})
+
+
+class FakeCast:
+    def __init__(self, uuid: str = "11111111-1111-1111-1111-111111111111") -> None:
+        self.uuid = UUID(uuid)
+        self.name = "Kitchen Cast"
+        self.model_name = "Nest Audio"
+        self.cast_type = "audio"
+        self.cast_info = SimpleNamespace(
+            uuid=self.uuid,
+            friendly_name=self.name,
+            host="192.0.2.55",
+            manufacturer="Google",
+            model_name=self.model_name,
+            cast_type=self.cast_type,
+        )
+        self.media_controller = FakeMediaController()
+        self.calls = []
+
+    def wait(self, timeout=None) -> None:
+        self.calls.append(("wait", timeout))
+
+    def start_app(self, app_id, force_launch=False, timeout=10) -> None:
+        self.calls.append(("start_app", app_id, force_launch, timeout))
+
+    def set_volume(self, volume) -> None:
+        self.calls.append(("set_volume", volume))
+
+    def set_volume_muted(self, muted) -> None:
+        self.calls.append(("set_volume_muted", muted))
+
+    def disconnect(self, timeout=None) -> None:
+        self.calls.append(("disconnect", timeout))
+
+    def quit_app(self, timeout=10.0) -> None:
+        self.calls.append(("quit_app", timeout))
+
+
+@pytest.mark.asyncio
+async def test_phase2_cast_discovery_creates_normalized_devices():
+    cast = FakeCast()
+
+    def getter(**kwargs):
+        return [cast], FakeBrowser()
+
+    backend = CastRendererBackend(chromecast_getter=getter)
+
+    devices = await backend.discover(refresh=True)
+
+    assert len(devices) == 1
+    device = devices[0]
+    assert device.renderer_id == "cast:11111111-1111-1111-1111-111111111111"
+    assert device.kind == "cast"
+    assert device.native_id == "11111111-1111-1111-1111-111111111111"
+    assert device.name == "Kitchen Cast"
+    assert device.ip == "192.0.2.55"
+    assert device.cast_type == "audio"
+    assert device.capabilities.supports_events is True
+
+
+@pytest.mark.asyncio
+async def test_phase2_cast_manual_known_host_passed_to_discovery():
+    cast = FakeCast()
+    calls = []
+
+    def getter(**kwargs):
+        calls.append(kwargs)
+        return [cast], FakeBrowser()
+
+    backend = CastRendererBackend(chromecast_getter=getter)
+
+    device = await backend.add_manual("192.0.2.55")
+
+    assert device is not None
+    assert calls[0]["known_hosts"] == ["192.0.2.55"]
+
+
+@pytest.mark.asyncio
+async def test_phase2_cast_play_and_controls_call_pychromecast_shape():
+    cast = FakeCast()
+    backend = CastRendererBackend(chromecast_getter=lambda **_: ([cast], FakeBrowser()))
+    await backend.discover(refresh=True)
+    renderer_id = "cast:11111111-1111-1111-1111-111111111111"
+
+    await backend.play_track(
+        renderer_id,
+        {
+            "id": 902,
+            "path": "/music/song.flac",
+            "title": "Song",
+            "artist": "Artist",
+            "album": "Album",
+            "mime": "audio/flac",
+            "duration_seconds": 180,
+        },
+        PlaybackContext(base_url="http://127.0.0.1:8111", user_id=42, token_ttl_seconds=1800),
+    )
+    await backend.pause(renderer_id)
+    await backend.resume(renderer_id)
+    await backend.seek(renderer_id, 33)
+    await backend.set_volume(renderer_id, 65)
+    await backend.stop_playback(renderer_id)
+    await backend.get_status(renderer_id)
+
+    assert cast.calls[0] == ("wait", 10)
+    assert cast.calls[1][0] == "start_app"
+    play_call = cast.media_controller.calls[0]
+    assert play_call[0] == "play_media"
+    assert play_call[1][0].startswith("http://127.0.0.1:8111/api/stream/902?token=")
+    assert play_call[1][1] == "audio/flac"
+    assert play_call[2]["title"] == "Song"
+    assert ("pause", (), {}) in cast.media_controller.calls
+    assert ("play", (), {}) in cast.media_controller.calls
+    assert ("seek", (33,), {}) in cast.media_controller.calls
+    assert ("stop", (), {}) in cast.media_controller.calls
+    assert ("update_status", (), {}) in cast.media_controller.calls
+    assert ("set_volume", 0.65) in cast.calls
+    assert ("quit_app", 10) in cast.calls
+
+
+def test_phase2_cast_status_mapping_and_end_detection():
+    backend = CastRendererBackend()
+    renderer_id = "cast:11111111-1111-1111-1111-111111111111"
+    status = SimpleNamespace(
+        player_state="IDLE",
+        adjusted_current_time=180,
+        duration=180,
+        volume_level=0.5,
+        volume_muted=False,
+        content_id="http://media",
+    )
+
+    mapped = backend.status_from_media_status(
+        renderer_id,
+        status,
+        previous_state="PLAYING",
+        started_at=0,
+    )
+
+    assert mapped.state == "IDLE"
+    assert mapped.ended is True
+    assert mapped.position_seconds == 180
+    assert mapped.duration_seconds == 180
+    assert mapped.volume_percent == 50
+
+
+def test_phase2_cast_early_idle_does_not_stop_playback():
+    backend = CastRendererBackend()
+    renderer_id = "cast:11111111-1111-1111-1111-111111111111"
+    status = SimpleNamespace(
+        player_state="IDLE",
+        adjusted_current_time=0,
+        duration=None,
+        volume_level=None,
+        volume_muted=False,
+        content_id=None,
+    )
+
+    mapped = backend.status_from_media_status(
+        renderer_id,
+        status,
+        previous_state="UNKNOWN",
+        started_at=time.time(),
+    )
+
+    assert mapped.state == "UNKNOWN"
+    assert mapped.ended is False
+
+
+@pytest.mark.asyncio
+async def test_phase2_cast_status_listener_dispatches_to_async_callback():
+    cast = FakeCast()
+    backend = CastRendererBackend(chromecast_getter=lambda **_: ([cast], FakeBrowser()))
+    await backend.start()
+    renderer_id = "cast:11111111-1111-1111-1111-111111111111"
+    received = []
+
+    async def callback(status):
+        received.append(status)
+
+    backend.register_status_listener(renderer_id, callback)
+    listener = cast.media_controller.listeners[0]
+    listener.last_state = "PLAYING"
+    listener.started_at = 0
+    listener.new_media_status(SimpleNamespace(player_state="IDLE", current_time=99, duration=99))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert received
+    assert received[0].ended is True

--- a/uv.lock
+++ b/uv.lock
@@ -262,6 +262,18 @@ wheels = [
 ]
 
 [[package]]
+name = "casttube"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/54/f7e80d701c587940cf1c871fb6327b4a2682df4287896fbf9400cd0bbf21/casttube-0.2.1.tar.gz", hash = "sha256:54d2af8c7949aa9c5db87fb11ef0a478a5d3e7ac6d2d2ac8dd1711e3a516fc82", size = 5182, upload-time = "2020-04-08T12:54:07.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/d2/0f5006892e07ea342d57dbeda46027e99a097ffb6218bee1e37f9776ed95/casttube-0.2.1-py3-none-any.whl", hash = "sha256:36f118007f9eead3959cf30de03c1640b53a263569ff2a3971c0521826c835b2", size = 6513, upload-time = "2020-04-08T12:54:06.107Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -301,6 +313,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -563,6 +616,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +652,7 @@ dependencies = [
     { name = "mutagen" },
     { name = "pillow" },
     { name = "pycares" },
+    { name = "pychromecast" },
     { name = "pylast" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
@@ -598,6 +661,7 @@ dependencies = [
     { name = "rich" },
     { name = "slowapi" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "zeroconf" },
 ]
 
 [package.dev-dependencies]
@@ -624,6 +688,7 @@ requires-dist = [
     { name = "mutagen" },
     { name = "pillow" },
     { name = "pycares", specifier = ">=5.0.0" },
+    { name = "pychromecast", specifier = ">=14.0.0" },
     { name = "pylast", specifier = ">=7.0.1" },
     { name = "python-jose", extras = ["cryptography"] },
     { name = "python-multipart" },
@@ -632,6 +697,7 @@ requires-dist = [
     { name = "rich" },
     { name = "slowapi" },
     { name = "uvicorn", extras = ["standard"] },
+    { name = "zeroconf", specifier = ">=0.130.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -822,6 +888,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -863,6 +944,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/06/19/1603f51f0d73bf34017a9e6967540c2bc138f9541aa7cc1ef38990b3ce9d/pycares-5.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:145d8a20f7fd1d58a2e49b7ef4309ec9bdcab479ac65c2e49480e20d3f890c23", size = 232027, upload-time = "2026-01-01T12:36:34.374Z" },
     { url = "https://files.pythonhosted.org/packages/7a/de/c000a682757b84688722ac232a24a86b6f195f1f4732432ecf35d0a768a5/pycares-5.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ebc9daba03c7ff3f62616c84c6cb37517445d15df00e1754852d6006039eb4a4", size = 121267, upload-time = "2026-01-01T12:36:35.741Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c4/8bfffecd08b9b198113fcff5f0ab84bbe696f07dec46dd1ccae0e7b28c23/pycares-5.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:e0a86eff6bf9e91d5dd8876b1b82ee45704f46b1104c24291d3dea2c1fc8ebcb", size = 113043, upload-time = "2026-01-01T12:36:37.895Z" },
+]
+
+[[package]]
+name = "pychromecast"
+version = "14.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "casttube" },
+    { name = "protobuf" },
+    { name = "zeroconf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/1f/d78497441334d24740cce0a92394c33972a9d6a17b607d0ec976f0f48a35/pychromecast-14.0.10.tar.gz", hash = "sha256:f05a1c8d727d4f104c8c731688053033e05157f2ab81bc8eef50ec0c62f9373c", size = 61588, upload-time = "2026-03-07T16:37:42.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/61/f0f176622e2b4df06318a3abb2a27cc4c2fee8d40d7a0db8d60034785c09/pychromecast-14.0.10-py2.py3-none-any.whl", hash = "sha256:f5ea52b1db0edc3019ec72c9f5354c7e77c2564ecd44f809a6d2f4f518a02e67", size = 77467, upload-time = "2026-03-07T16:37:41.527Z" },
 ]
 
 [[package]]
@@ -1095,6 +1190,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1315,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]
@@ -1380,4 +1499,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zeroconf"
+version = "0.148.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/46/10db987799629d01930176ae523f70879b63577060d63e05ebf9214aba4b/zeroconf-0.148.0.tar.gz", hash = "sha256:03fcca123df3652e23d945112d683d2f605f313637611b7d4adf31056f681702", size = 164447, upload-time = "2025-10-05T00:21:19.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/46/ac86e3a3ff355058cd0818b01a3a97ca3f2abc0a034f1edb8eea27cea65c/zeroconf-0.148.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:2158d8bfefcdb90237937df65b2235870ccef04644497e4e29d3ab5a4b3199b6", size = 1714870, upload-time = "2025-10-05T01:08:47.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/02/c5e8cd8dfda0ca16c7309c8d12c09a3114e5b50054bce3c93da65db8b8e4/zeroconf-0.148.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:695f6663bf8df30fe1826a2c4d5acd8213d9cbd9111f59d375bf1ad635790e98", size = 1697756, upload-time = "2025-10-05T01:08:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/63/04/a66c1011d05d7bb8ae6a847d41ac818271a942390f3d8c83c776389ca094/zeroconf-0.148.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa65a24ec055be0a1cba2b986ac3e1c5d97a40abe164991aabc6a6416cc9df02", size = 2146784, upload-time = "2025-10-05T01:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d4/2239d87c3f60f886bd2dd299e9c63b811efd58b8b6fc659d8fd0900db3bc/zeroconf-0.148.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:79890df4ff696a5cdc4a59152957be568bea1423ed13632fc09e2a196c6721d5", size = 1899394, upload-time = "2025-10-05T01:08:53.457Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/60/534a4b576a8f9f5edff648ac9a5417323bef3086a77397f2f2058125a3c8/zeroconf-0.148.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c0ca6e8e063eb5a385469bb8d8dec12381368031cb3a82c446225511863ede3", size = 2221319, upload-time = "2025-10-05T01:08:55.271Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/8c/1c8e9b7d604910830243ceb533d796dae98ed0c72902624a642487edfd61/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ece6f030cc7a771199760963c11ce4e77ed95011eedffb1ca5186247abfec24a", size = 2178586, upload-time = "2025-10-05T01:08:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/16/55/178c4b95840dc687d45e413a74d2236a25395ab036f4813628271306ab9d/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c3f860ad0003a8999736fa2ae4c2051dd3c2e5df1bc1eaea2f872f5fcbd1f1c1", size = 1972371, upload-time = "2025-10-05T01:08:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/86/b599421fe634d9f3a2799f69e6e7db9f13f77d326331fa2bb5982e936665/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ab8e687255cf54ebeae7ede6a8be0566aec752c570e16dbea84b3f9b149ba829", size = 2244286, upload-time = "2025-10-05T01:09:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cb/a30c42057be5da6bb4cbe1ab53bc3a7d9a29cd59caae097d3072a9375c14/zeroconf-0.148.0-cp314-cp314-win32.whl", hash = "sha256:6b1a6ddba3328d741798c895cecff21481863eb945c3e5d30a679461f4435684", size = 1321693, upload-time = "2025-10-05T01:09:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/38/06873cdf769130af463ef5acadbaf4a50826a7274374bc3b9a4ec5d32678/zeroconf-0.148.0-cp314-cp314-win_amd64.whl", hash = "sha256:2588f1ca889f57cdc09b3da0e51175f1b6153ce0f060bf5eb2a8804c5953b135", size = 1563980, upload-time = "2025-10-05T01:09:04.857Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fb/53d749793689279bc9657d818615176577233ad556d62f76f719e86ead1d/zeroconf-0.148.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:40fe100381365c983a89e4b219a7ececcc2a789ac179cd26d4a6bbe00ae3e8fe", size = 3418152, upload-time = "2025-10-05T01:09:06.71Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/19/5eb647f7277378cbfdb6943dc8e60c3b17cdd1556f5082ccfdd6813e1ce8/zeroconf-0.148.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0b9c7bcae8af8e27593bad76ee0f0c21d43c6a2324cd1e34d06e6e08cb3fd922", size = 3389671, upload-time = "2025-10-05T01:09:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/3134aa54d30a9ae2e2473212eab586fe1779f845bf241e68729eca63d2ab/zeroconf-0.148.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8ba75dacd58558769afb5da24d83da4fdc2a5c43a52f619aaa107fa55d3fdc", size = 4123125, upload-time = "2025-10-05T01:09:11.064Z" },
+    { url = "https://files.pythonhosted.org/packages/12/23/4a0284254ebce373ff1aee7240932a0599ecf47e3c711f93242a861aa382/zeroconf-0.148.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:75f9a8212c541a4447c064433862fd4b23d75d47413912a28204d2f9c4929a59", size = 3651426, upload-time = "2025-10-05T01:09:13.725Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9a/7b79ef986b5467bb8f17b9a9e6eea887b0b56ecafc00515c81d118e681b4/zeroconf-0.148.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be64c0eb48efa1972c13f7f17a7ac0ed7932ebb9672e57f55b17536412146206", size = 4263151, upload-time = "2025-10-05T01:09:15.732Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0a/caa6d05548ca7cf28a0b8aa20a9dbb0f8176172f28799e53ea11f78692a3/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac1d4ee1d5bac71c27aea6d1dc1e1485423a1631a81be1ea65fb45ac280ade96", size = 4191717, upload-time = "2025-10-05T01:09:18.071Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f6/dbafa3b0f2d7a09315ed3ad588d36de79776ce49e00ec945c6195cad3f18/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8da9bdb39ead9d5971136046146cd5e11413cb979c011e19f717b098788b5c37", size = 3793490, upload-time = "2025-10-05T01:09:20.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/05/f8b88937659075116c122355bdd9ce52376cc46e2269d91d7d4f10c9a658/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6e3dd22732df47a126aefb5ca4b267e828b47098a945d4468d38c72843dd6df", size = 4311455, upload-time = "2025-10-05T01:09:22.042Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c0/359bdb3b435d9c573aec1f877f8a63d5e81145deb6c160de89647b237363/zeroconf-0.148.0-cp314-cp314t-win32.whl", hash = "sha256:cdc8083f0b5efa908ab6c8e41687bcb75fd3d23f49ee0f34cbc58422437a456f", size = 2755961, upload-time = "2025-10-05T01:09:24.041Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ab/7b487afd5d1fd053c5a018565be734ac6d5e554bce938c7cc126154adcfc/zeroconf-0.148.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f72c1f77a89638e87f243a63979f0fd921ce391f83e18e17ec88f9f453717701", size = 3309977, upload-time = "2025-10-05T01:09:26.039Z" },
 ]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4069,6 +4069,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte/node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",

--- a/web/src/lib/components/PlayerBar.svelte
+++ b/web/src/lib/components/PlayerBar.svelte
@@ -525,11 +525,10 @@
 
     // Initial Volume Sync: Capture browser-restored volume
     if (audio) {
-      // Only update store if it has NOT been initialized yet (null)
-      // This prevents overwriting a server-fetched value with a default/local value
-      if ($playerState.volume === null) {
-
-        // We update the store, and rely on `player.ts` to NOT overwrite this with null.
+      // Only seed browser volume for local playback.
+      // Remote renderers must pull volume from the device — defaulting
+      // to 100 would blast full volume on first slider touch.
+      if ($playerState.volume === null && $playerState.renderer.includes("local")) {
         playerState.update((s) => ({
           ...s,
           volume: Math.round(audio.volume * 100),
@@ -680,10 +679,10 @@
     let lastTransportState = "";
 
     const interval = setInterval(async () => {
-      if (
+      const shouldPollRemote =
         !$playerState.renderer.startsWith("local") &&
-        $playerState.is_playing
-      ) {
+        ($playerState.is_playing || Boolean(currentTrack));
+      if (shouldPollRemote) {
         try {
           const res = await fetchWithAuth("/api/player/state", {
             headers: getHeaders(),
@@ -729,6 +728,16 @@
               // Optional: Sync queue if needed (e.g. length changed)
               if (s.queue.length !== state.queue.length) {
                 newState.queue = state.queue;
+                changed = true;
+              }
+
+              // Sync volume from device for remote renderers
+              if (
+                state.volume !== null &&
+                state.volume !== undefined &&
+                s.volume !== state.volume
+              ) {
+                newState.volume = state.volume;
                 changed = true;
               }
 

--- a/web/src/lib/components/VolumeControl.svelte
+++ b/web/src/lib/components/VolumeControl.svelte
@@ -7,16 +7,18 @@
     export let sliderStyle = "";
     export let containerClass = "flex items-center gap-2 group";
 
-    let volume = 1.0;
+    let volume = ($playerState.volume != null) ? $playerState.volume / 100 : 0.5;
 
-    // Sync from store
+    // Sync from store (0-100 → 0-1). When store is null (e.g. remote
+    // renderer selected, device volume not yet known), default to 50%
+    // to avoid blasting full volume on first slider touch.
     $: if ($playerState.volume !== null && $playerState.volume !== undefined) {
-        // Store is 0-100, local is 0-1
         const newVol = $playerState.volume / 100;
         if (Math.abs(volume - newVol) > 0.01) {
             volume = newVol;
         }
     } else {
+        volume = 0.5;
     }
 
     function handleInput(e: Event) {

--- a/web/src/lib/stores/player.ts
+++ b/web/src/lib/stores/player.ts
@@ -4,8 +4,12 @@ import { fetchWithAuth } from '$lib/api';
 
 export interface Renderer {
     udn: string;
+    renderer_id?: string;
     name: string;
     type: string;
+    kind?: string;
+    native_id?: string;
+    cast_type?: string;
     icon_url?: string;
     icon_mime?: string;
     icon_width?: number;
@@ -141,7 +145,15 @@ export async function setRenderer(udn: string) {
         if (res.ok) {
             const data = await res.json();
             const active = data.active || udn;
-            playerState.update(s => ({ ...s, renderer: active }));
+            // Reset volume for remote renderers — device volume is unknown
+            // until the next sync_status poll fetches it.  Prevents stale
+            // volume from previous renderer leaking into the new one.
+            const isRemote = !active.startsWith("local");
+            playerState.update(s => ({
+                ...s,
+                renderer: active,
+                volume: isRemote ? null : s.volume,
+            }));
             await loadQueueFromServer();
         }
     } catch (e) {
@@ -336,13 +348,7 @@ export async function clearQueue(stopPlayback: boolean = true) {
                 transport_state: 'STOPPED'
             }));
 
-            if (stopPlayback) {
-                try {
-                    await pause();
-                } catch (err) {
-                    console.warn('[clearQueue] Failed to pause after clear:', err);
-                }
-            }
+            void stopPlayback;
         } else {
             console.error('[clearQueue] Failed, status:', res.status, await res.text());
         }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -76,6 +76,34 @@
     return getRendererFallback(renderer);
   }
 
+  function rendererKind(renderer: any): string {
+    const raw = renderer?.kind || renderer?.type || renderer?.renderer_id?.split(":")[0] || "";
+    if (raw === "cast" || raw === "chromecast") return "cast";
+    if (raw === "upnp" || renderer?.udn?.startsWith("uuid:")) return "upnp";
+    if (raw === "local" || renderer?.udn?.startsWith("local:")) return "local";
+    return raw || "unknown";
+  }
+
+  function rendererKindLabel(renderer: any): string {
+    const kind = rendererKind(renderer);
+    if (kind === "cast") {
+      const castType = renderer?.cast_type;
+      if (!castType || castType === "cast") return "Cast";
+      return `Cast ${castType}`;
+    }
+    if (kind === "upnp") return "UPnP";
+    if (kind === "local") return "Local";
+    return kind.toUpperCase();
+  }
+
+  function rendererKindClass(renderer: any): string {
+    const kind = rendererKind(renderer);
+    if (kind === "cast") return "border-sky-400/40 bg-sky-500/15 text-sky-300";
+    if (kind === "upnp") return "border-emerald-400/40 bg-emerald-500/15 text-emerald-300";
+    if (kind === "local") return "border-zinc-400/30 bg-zinc-500/15 text-zinc-300";
+    return "border-subtle bg-surface-3 text-muted";
+  }
+
   // Track whether we're on an auth page
   $: isAuthPage = $page.url.pathname.startsWith("/login");
   $: activeRendererItem = rendererList.find((r) => r.udn === activeRenderer);
@@ -301,6 +329,13 @@
                 <span class="truncate max-w-[170px]">
                   {activeRendererItem?.name || "Select Player"}
                 </span>
+                {#if activeRendererItem}
+                  <span
+                    class={`hidden shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide sm:inline-flex ${rendererKindClass(activeRendererItem)}`}
+                  >
+                    {rendererKindLabel(activeRendererItem)}
+                  </span>
+                {/if}
               </span>
               <svg
                 class={`h-4 w-4 opacity-50 ${renderersLoading ? "animate-pulse" : ""}`}
@@ -344,7 +379,12 @@
                               getRendererFallback(renderer);
                           }}
                         />
-                        <span class="truncate">{renderer.name}</span>
+                        <span class="min-w-0 flex-1 truncate">{renderer.name}</span>
+                        <span
+                          class={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide ${rendererKindClass(renderer)}`}
+                        >
+                          {rendererKindLabel(renderer)}
+                        </span>
                       </span>
                       {#if activeRenderer === renderer.udn}
                         <svg
@@ -513,6 +553,13 @@
               <span class="max-w-[72px] truncate text-left">
                 {activeRendererItem?.name || "Player"}
               </span>
+              {#if activeRendererItem}
+                <span
+                  class={`hidden shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide sm:inline-flex ${rendererKindClass(activeRendererItem)}`}
+                >
+                  {rendererKindLabel(activeRendererItem)}
+                </span>
+              {/if}
             </button>
             {/if}
             <button
@@ -554,7 +601,12 @@
                           getRendererFallback(renderer);
                       }}
                     />
-                    <span class="truncate">{renderer.name}</span>
+                    <span class="min-w-0 flex-1 truncate">{renderer.name}</span>
+                    <span
+                      class={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide ${rendererKindClass(renderer)}`}
+                    >
+                      {rendererKindLabel(renderer)}
+                    </span>
                   </span>
                   {#if activeRenderer === renderer.udn}
                     <svg class="h-4 w-4 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/routes/renderers/+page.svelte
+++ b/web/src/routes/renderers/+page.svelte
@@ -46,6 +46,44 @@
         return getRendererFallback(renderer);
     }
 
+    function rendererKind(renderer: any): string {
+        const raw =
+            renderer?.kind ||
+            renderer?.type ||
+            renderer?.renderer_id?.split(":")[0] ||
+            "";
+        if (raw === "cast" || raw === "chromecast") return "cast";
+        if (raw === "upnp" || renderer?.udn?.startsWith("uuid:")) return "upnp";
+        if (raw === "local" || renderer?.udn?.startsWith("local:")) return "local";
+        return raw || "unknown";
+    }
+
+    function rendererKindLabel(renderer: any): string {
+        const kind = rendererKind(renderer);
+        if (kind === "cast") {
+            const castType = renderer?.cast_type;
+            if (!castType || castType === "cast") return "Cast";
+            return `Cast ${castType}`;
+        }
+        if (kind === "upnp") return "UPnP";
+        if (kind === "local") return "Local";
+        return kind.toUpperCase();
+    }
+
+    function rendererKindClass(renderer: any): string {
+        const kind = rendererKind(renderer);
+        if (kind === "cast") {
+            return "border-sky-400/40 bg-sky-500/15 text-sky-300";
+        }
+        if (kind === "upnp") {
+            return "border-emerald-400/40 bg-emerald-500/15 text-emerald-300";
+        }
+        if (kind === "local") {
+            return "border-zinc-400/30 bg-zinc-500/15 text-zinc-300";
+        }
+        return "border-subtle bg-surface-3 text-muted";
+    }
+
     let scanStatus = "";
     let scanProgress = 0;
     let scanLogs: string[] = [];
@@ -147,7 +185,7 @@
     {/if}
 
     <p class="mb-6 text-muted">
-        Discovered UPnP/DLNA media renderers on your network.
+        Discovered network media renderers.
     </p>
 
     <div class="grid gap-4 grid-cols-1">
@@ -194,9 +232,16 @@
                         >
                             {r.name}
                         </h3>
-                        <span class="text-xs text-subtle font-mono"
-                            >{r.ip || "Local"}</span
-                        >
+                        <div class="mt-1 flex flex-wrap items-center gap-2">
+                            <span
+                                class={`rounded-sm border px-2 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide ${rendererKindClass(r)}`}
+                            >
+                                {rendererKindLabel(r)}
+                            </span>
+                            <span class="text-xs text-subtle font-mono"
+                                >{r.ip || "Local"}</span
+                            >
+                        </div>
                     </div>
                 </div>
 
@@ -218,6 +263,16 @@
                                     <span class="text-subtle">Model</span>
                                     <span class="text-muted"
                                         >{r.model_name}</span
+                                    >
+                                </div>
+                            {/if}
+                            {#if r.renderer_id}
+                                <div class="flex flex-col gap-1 text-sm sm:flex-row sm:justify-between">
+                                    <span class="text-subtle">Renderer ID</span>
+                                    <span
+                                        class="text-muted font-mono text-xs truncate"
+                                        title={r.renderer_id}
+                                        >{r.renderer_id}</span
                                     >
                                 </div>
                             {/if}


### PR DESCRIPTION
## Summary

- New `CastRendererBackend` with pychromecast integration — discovery, playback, status listeners, volume/mute control
- Protocol-neutral `RendererOrchestrator` that routes operations to any backend (UPnP, Cast, local) without callers branching on renderer type
- `RendererRegistry` with backend registration/discovery/persistence, shared `RendererDevice`/`RendererStatus` contracts, and LAN-aware stream token TTL policy
- Track advancement driven by position-vs-duration detection + IDLE polling, with targeted DB writes to prevent lost-update races on `current_index`
- In-memory history dedup via `should_log_history` tracker
- Volume: null slate on remote renderer select resets slider to 50% until device volume is polled
- Frontend: renderer picker with Cast/UPnP/Local badges and icons, Cast-specific status display
- 38 files, ~4500 insertions. Test suite: 347 passed, 1 skipped.

## Open items

- Volume initialization for Cast devices needs user verification
- Custom receiver app for branded Cast UI (deferred to v2)
- AirPlay 2 backend (sibling issue)