### PR TITLE
fix: address security scans, refresh storms, and stream auth issues

### DIFF
--- a/android/app/src/main/java/com/jamarr/android/data/JamarrApiClient.kt
+++ b/android/app/src/main/java/com/jamarr/android/data/JamarrApiClient.kt
@@ -47,6 +47,11 @@ class JamarrApiClient(
     private val refreshLock = Any()
     private val callbackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    // Cooldown after a refresh fails to prevent loops (e.g. background loops
+    // that keep firing requests while the refresh token is permanently invalid).
+    @Volatile private var refreshFailedAtMs: Long = 0L
+    private val refreshCooldownMs: Long = 60_000L
+
     private val authInterceptor = Interceptor { chain ->
         val original = chain.request()
         val path = original.url.encodedPath
@@ -92,6 +97,13 @@ class JamarrApiClient(
             if (current.isNotBlank() && current != failedToken) {
                 return current
             }
+            val now = System.currentTimeMillis()
+            val sinceFailure = now - refreshFailedAtMs
+            if (refreshFailedAtMs > 0L && sinceFailure < refreshCooldownMs) {
+                // Recent refresh failure — don't hammer the server. Caller
+                // should treat this as an auth failure and stop retrying.
+                return null
+            }
             val refreshUrl = originalUrl.newBuilder()
                 .encodedPath("/api/auth/refresh")
                 .query(null)
@@ -109,10 +121,12 @@ class JamarrApiClient(
                 }
             }.getOrNull()
             return if (newToken.isNullOrBlank()) {
+                refreshFailedAtMs = System.currentTimeMillis()
                 tokenHolder.clear()
                 callbackScope.launch { onRefreshFailed() }
                 null
             } else {
+                refreshFailedAtMs = 0L
                 tokenHolder.set(newToken)
                 callbackScope.launch { onTokenRefreshed(newToken) }
                 newToken

--- a/android/app/src/main/java/com/jamarr/android/playback/JamarrPlaybackService.kt
+++ b/android/app/src/main/java/com/jamarr/android/playback/JamarrPlaybackService.kt
@@ -42,7 +42,12 @@ class JamarrPlaybackService : MediaLibraryService() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val serverUrl = AtomicReference("")
-    private val streamUrlCache = ConcurrentHashMap<Long, String>()
+
+    // Resolved /api/stream/<id>?token=<jwt> URLs. The stream token expires
+    // (default 300s server-side) so cached URLs must not outlive the token,
+    // otherwise ExoPlayer reopens with a stale token and gets 401.
+    private data class CachedStreamUrl(val url: String, val expiresAtMs: Long)
+    private val streamUrlCache = ConcurrentHashMap<Long, CachedStreamUrl>()
     private lateinit var settingsStore: SettingsStore
     private lateinit var tokenHolder: TokenHolder
     private lateinit var apiClient: JamarrApiClient
@@ -113,14 +118,17 @@ class JamarrPlaybackService : MediaLibraryService() {
                         }
                         for (i in 0 until player.mediaItemCount) {
                             val tid = extractTrackId(player.getMediaItemAt(i).mediaId)
-                            if (tid > 0L && !streamUrlCache.containsKey(tid)) {
+                            if (tid > 0L && !isStreamUrlFresh(tid)) {
                                 serviceScope.launch(Dispatchers.IO) {
                                     runCatching {
                                         withTimeout(5000) {
                                             apiClient.streamUrl(url, tokenHolder.get(), tid)
                                         }
                                     }.onSuccess { resolved ->
-                                        streamUrlCache[tid] = resolved
+                                        streamUrlCache[tid] = CachedStreamUrl(
+                                            url = resolved,
+                                            expiresAtMs = System.currentTimeMillis() + STREAM_URL_TTL_MS,
+                                        )
                                     }
                                 }
                             }
@@ -172,15 +180,29 @@ class JamarrPlaybackService : MediaLibraryService() {
         val server = serverUrl.get()
         if (server.isBlank()) throw IOException("Jamarr server URL not set")
 
-        streamUrlCache[trackId]?.let { return spec.withUri(Uri.parse(it)) }
+        val now = System.currentTimeMillis()
+        streamUrlCache[trackId]?.let { cached ->
+            if (cached.expiresAtMs > now) {
+                return spec.withUri(Uri.parse(cached.url))
+            }
+            streamUrlCache.remove(trackId)
+        }
 
         val resolved = runBlocking {
             withTimeout(5000) {
                 apiClient.streamUrl(server, tokenHolder.get(), trackId)
             }
         }
-        streamUrlCache[trackId] = resolved
+        streamUrlCache[trackId] = CachedStreamUrl(
+            url = resolved,
+            expiresAtMs = System.currentTimeMillis() + STREAM_URL_TTL_MS,
+        )
         return spec.withUri(Uri.parse(resolved))
+    }
+
+    private fun isStreamUrlFresh(trackId: Long): Boolean {
+        val cached = streamUrlCache[trackId] ?: return false
+        return cached.expiresAtMs > System.currentTimeMillis()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
@@ -228,6 +250,10 @@ class JamarrPlaybackService : MediaLibraryService() {
 
     companion object {
         const val JAMARR_SCHEME = "jamarr"
+
+        // Server default STREAM_TOKEN_TTL_SECONDS=300. Cache for 240s so a
+        // pre-warmed URL still has ~60s of validity when ExoPlayer opens it.
+        const val STREAM_URL_TTL_MS = 240_000L
 
         fun trackUri(trackId: Long): Uri =
             Uri.parse("$JAMARR_SCHEME://track/$trackId")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -255,6 +255,7 @@ async def logout(
 
 
 @router.post("/api/auth/refresh")
+@limiter.limit("10/minute")
 async def refresh(
     request: Request, response: Response, db: asyncpg.Connection = Depends(get_db)
 ):

--- a/app/api/library.py
+++ b/app/api/library.py
@@ -78,22 +78,27 @@ async def get_missing_albums(mbid: str, db: asyncpg.Connection = Depends(get_db)
 async def download_pearlarr(req: PearlarrDownloadRequest):
     pearlarr_url = get_pearlarr_url()
     if not pearlarr_url:
-        raise HTTPException(status_code=500, detail="Pearlarr URL not configured")
+        raise HTTPException(
+            status_code=503, detail="Pearlarr integration not configured"
+        )
 
     try:
-        async with httpx.AsyncClient() as client:
-            # Pearlarr expects {"url": "MBID"}
-            payload = {"url": req.mbid}
-            resp = await client.post(pearlarr_url, json=payload, timeout=5.0)
-            
-            if resp.status_code >= 400:
-                 logger.error(f"Pearlarr returned {resp.status_code}: {resp.text}")
-                 raise HTTPException(status_code=500, detail=f"Pearlarr error: {resp.status_code}")
-                 
-            return {"status": "queued", "message": "Download queued via Pearlarr"}
-    except Exception as e:
-        logger.error(f"Failed to trigger Pearlarr download: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(pearlarr_url, json={"url": req.mbid})
+    except httpx.TimeoutException:
+        logger.warning("Pearlarr request timed out: url=%s mbid=%s", pearlarr_url, req.mbid)
+        raise HTTPException(status_code=504, detail="Pearlarr did not respond in time")
+    except httpx.HTTPError as e:
+        logger.warning("Pearlarr request failed: %s", e)
+        raise HTTPException(status_code=502, detail="Pearlarr unreachable")
+
+    if resp.status_code >= 400:
+        logger.warning(
+            "Pearlarr returned %s: %s", resp.status_code, resp.text[:500]
+        )
+        raise HTTPException(status_code=502, detail="Pearlarr rejected request")
+
+    return {"status": "queued", "message": "Download queued via Pearlarr"}
 
 
 @router.get("/api/artists/index")

--- a/app/api/player.py
+++ b/app/api/player.py
@@ -53,6 +53,22 @@ async def get_client_id(x_jamarr_client_id: Optional[str] = Header(None)) -> str
     return x_jamarr_client_id
 
 
+def _translate_renderer_error(action: str, exc: Exception) -> HTTPException:
+    """Map renderer/backend exceptions to client-facing HTTP errors.
+
+    ValueError comes from the registry when no backend matches the active
+    renderer (stale session or removed backend) — return 409.
+    Anything else is a transport/control failure on the device side — return 502.
+    """
+    logger.warning("Renderer %s failed: %s", action, exc, exc_info=True)
+    if isinstance(exc, ValueError):
+        return HTTPException(
+            status_code=409,
+            detail="Active renderer is unavailable. Re-select a device.",
+        )
+    return HTTPException(status_code=502, detail=f"Renderer {action} failed")
+
+
 @router.get("/api/client-ip")
 async def get_client_ip_endpoint(request: Request):
     return {"ip": get_client_ip(request)}
@@ -344,7 +360,12 @@ async def clear_queue(client_id: str = Depends(get_client_id)):
     Empty the active renderer queue and stop playback.
     """
     async for db in get_db():
-        state, udn = await renderer_orchestrator.stop_or_clear(db, client_id)
+        try:
+            state, udn = await renderer_orchestrator.stop_or_clear(db, client_id)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise _translate_renderer_error("clear", e)
 
         return {
             "status": "ok",
@@ -366,7 +387,12 @@ async def clear_queue(client_id: str = Depends(get_client_id)):
 )
 async def set_index(update: IndexUpdate, client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        state, udn = await renderer_orchestrator.skip_to_index(db, client_id, update.index)
+        try:
+            state, udn = await renderer_orchestrator.skip_to_index(db, client_id, update.index)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise _translate_renderer_error("skip", e)
     # Return the state so the client can sync immediately
     return {
         "status": "ok",
@@ -582,7 +608,12 @@ async def play_track(
 )
 async def pause_playback(client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        await renderer_orchestrator.pause(db, client_id)
+        try:
+            await renderer_orchestrator.pause(db, client_id)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise _translate_renderer_error("pause", e)
         return {"status": "ok"}
 
 
@@ -592,7 +623,12 @@ async def pause_playback(client_id: str = Depends(get_client_id)):
 )
 async def resume_playback(client_id: str = Depends(get_client_id)):
     async for db in get_db():
-        await renderer_orchestrator.resume(db, client_id)
+        try:
+            await renderer_orchestrator.resume(db, client_id)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise _translate_renderer_error("resume", e)
 
     return {"status": "ok"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 from contextlib import asynccontextmanager
 import os
+import re
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from app.db import init_db, close_db
 from app.security import configure_security_middleware, fastapi_docs_config, is_production
 
@@ -108,17 +109,34 @@ else:
     print("Warning: web/build directory not found. Frontend will not be served.")
 
 
+# Paths that must never fall through to the SPA index. Scanners probe these and
+# a 200 (even if just the SvelteKit shell) lands the host in public exposure DBs.
+_BLOCKED_PATH_PATTERNS = re.compile(
+    r"""(?ix)
+    (^|/) \.git(/|$)
+    | (^|/) \.env (\.|/|$)
+    | (^|/) \.htaccess$
+    | (^|/) \.htpasswd$
+    | \.(php|phtml|asp|aspx|jsp|cgi)(/|$)
+    | (^|/) wp-(admin|login|content|includes|json) (/|$|\.)
+    | (^|/) phpmyadmin (/|$)
+    | (^|/) phpinfo (/|$|\.)
+    | (^|/) administrator (/|$)
+    | (^|/) \.well-known/ (?! security\.txt$ | acme-challenge/ )
+    """
+)
+
+
 @app.get("/{path:path}")
 async def spa(path: str):
     # Let API and art routes fall through to their handlers
     if path.startswith("api/") or path.startswith("art/"):
-        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Not Found")
 
+    if _BLOCKED_PATH_PATTERNS.search(path):
         raise HTTPException(status_code=404, detail="Not Found")
 
     if is_production() and path.rstrip("/") in {"docs", "redoc", "openapi.json"}:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Not Found")
 
     if '..' in path or '\0' in path or '\\' in path:
@@ -134,7 +152,5 @@ async def spa(path: str):
     index_path = build_dir / "index.html"
     if index_path.exists():
         return FileResponse(index_path)
-
-    from fastapi import HTTPException
 
     raise HTTPException(status_code=404, detail="Not Found")

--- a/app/media/art.py
+++ b/app/media/art.py
@@ -99,7 +99,7 @@ def _is_not_modified(request: Request, etag: str, stat_result: os.stat_result) -
     return False
 
 
-@router.get("/art/file/{sha1}")
+@router.api_route("/art/file/{sha1}", methods=["GET", "HEAD"])
 async def get_artwork_by_sha1(sha1: str, request: Request, max_size: int = 0):
     if len(sha1) != 40 or any(c not in '0123456789abcdefABCDEF' for c in sha1):
         raise HTTPException(status_code=400, detail="Invalid SHA1 format")


### PR DESCRIPTION
## Summary

Fixes surfaced by review of `/mnt/config/q-jamarr/jamarr/log/{access,security}.log`.

- **SPA fallback no longer 200s on sensitive paths.** `/.git/config`, `/.env`, `*.php`, `wp-*`, `phpmyadmin`, `phpinfo`, `administrator`, and unknown `.well-known/*` paths now return 404 from `app/main.py` instead of falling through to the SvelteKit shell. Stops the host showing up as exposed in LeakIX/Censys/GitFinder scans.
- **Rate-limit `/api/auth/refresh`.** One client looped at 5 s intervals and produced 76 `refresh_invalid` events in 6 minutes. Server now caps at `10/minute`; Android `JamarrApiClient` adds a 60 s cooldown after a failed refresh so background loops stop hammering the endpoint.
- **Android stream token expiry.** `JamarrPlaybackService.streamUrlCache` cached resolved `/api/stream/<id>?token=<jwt>` URLs forever, but the stream token's TTL is 300 s. ExoPlayer reopening the connection (seek, rebuffer, prefetch) replayed a stale token and got 401. Cache now carries `expiresAtMs` and entries are re-minted at 240 s.
- **`/api/download/pearlarr` error mapping.** Blanket 500 with `str(e)` leak replaced by 503 (not configured) / 504 (timeout) / 502 (upstream unreachable or 4xx).
- **`/api/player/{pause,resume,index,queue/clear}` error mapping.** Stale renderer sessions return 409, device transport failures return 502, instead of leaking 500.
- **`/art/file/<sha1>` accepts HEAD.** Internal cache-validation probes were getting 405 every ~4 min.