### PR TITLE
fix(android): share token/cookie instances via Application singleton

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <application
+        android:name=".JamarrApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/java/com/jamarr/android/JamarrApplication.kt
+++ b/android/app/src/main/java/com/jamarr/android/JamarrApplication.kt
@@ -1,0 +1,29 @@
+package com.jamarr.android
+
+import android.app.Application
+import com.jamarr.android.auth.SettingsStore
+import com.jamarr.android.auth.TokenHolder
+import com.jamarr.android.data.JamarrCookieJar
+
+class JamarrApplication : Application() {
+    lateinit var tokenHolder: TokenHolder
+        private set
+    lateinit var cookieJar: JamarrCookieJar
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        val settingsStore = SettingsStore(this)
+        tokenHolder = TokenHolder()
+        cookieJar = JamarrCookieJar(settingsStore)
+    }
+
+    companion object {
+        @Volatile
+        private var instance: JamarrApplication? = null
+
+        fun get(): JamarrApplication =
+            instance ?: throw IllegalStateException("JamarrApplication not initialized")
+    }
+}

--- a/android/app/src/main/java/com/jamarr/android/data/JamarrApiClient.kt
+++ b/android/app/src/main/java/com/jamarr/android/data/JamarrApiClient.kt
@@ -38,19 +38,26 @@ class JamarrApiClient(
     cookieJar: CookieJar = CookieJar.NO_COOKIES,
     private val onTokenRefreshed: suspend (String) -> Unit = {},
     private val onRefreshFailed: suspend () -> Unit = {},
+    private val onForceLogout: suspend () -> Unit = {},
     private val json: Json = Json {
         ignoreUnknownKeys = true
         coerceInputValues = true
     },
 ) {
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
-    private val refreshLock = Any()
     private val callbackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     // Cooldown after a refresh fails to prevent loops (e.g. background loops
     // that keep firing requests while the refresh token is permanently invalid).
     @Volatile private var refreshFailedAtMs: Long = 0L
     private val refreshCooldownMs: Long = 60_000L
+
+    companion object {
+        private val globalRefreshLock = Any()
+        private const val MAX_REFRESH_FAILURES = 2
+        @Volatile
+        var consecutiveRefreshFailures: Int = 0
+    }
 
     private val authInterceptor = Interceptor { chain ->
         val original = chain.request()
@@ -81,10 +88,7 @@ class JamarrApiClient(
         val req = response.request
         val path = req.url.encodedPath
         if (path.endsWith("/api/auth/login") || path.endsWith("/api/auth/refresh")) return null
-        if (response.priorResponse != null) {
-            callbackScope.launch { onRefreshFailed() }
-            return null
-        }
+        if (response.priorResponse != null) return null
         val failedAuth = req.header("Authorization")
         val failedToken = failedAuth?.removePrefix("Bearer ")?.trim()
         val newToken = refreshTokenSync(req.url, failedToken) ?: return null
@@ -92,7 +96,7 @@ class JamarrApiClient(
     }
 
     private fun refreshTokenSync(originalUrl: HttpUrl, failedToken: String?): String? {
-        synchronized(refreshLock) {
+        synchronized(globalRefreshLock) {
             val current = tokenHolder.get()
             if (current.isNotBlank() && current != failedToken) {
                 return current
@@ -122,11 +126,17 @@ class JamarrApiClient(
             }.getOrNull()
             return if (newToken.isNullOrBlank()) {
                 refreshFailedAtMs = System.currentTimeMillis()
+                consecutiveRefreshFailures++
                 tokenHolder.clear()
-                callbackScope.launch { onRefreshFailed() }
+                if (consecutiveRefreshFailures >= MAX_REFRESH_FAILURES) {
+                    callbackScope.launch { onForceLogout() }
+                } else {
+                    callbackScope.launch { onRefreshFailed() }
+                }
                 null
             } else {
                 refreshFailedAtMs = 0L
+                consecutiveRefreshFailures = 0
                 tokenHolder.set(newToken)
                 callbackScope.launch { onTokenRefreshed(newToken) }
                 newToken
@@ -145,7 +155,9 @@ class JamarrApiClient(
             .post(body)
             .build()
 
-        execute(request)
+        val response = execute<LoginResponse>(request)
+        consecutiveRefreshFailures = 0
+        response
     }
 
     suspend fun search(

--- a/android/app/src/main/java/com/jamarr/android/data/JamarrCookieJar.kt
+++ b/android/app/src/main/java/com/jamarr/android/data/JamarrCookieJar.kt
@@ -32,11 +32,14 @@ class JamarrCookieJar(
     private val store = mutableMapOf<String, MutableList<Cookie>>()
     private val json = Json { ignoreUnknownKeys = true }
     private val persistScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    @Volatile private var primed = false
 
     suspend fun prime() {
+        if (primed) return
         val stored = settingsStore.loadCookies()
         val now = System.currentTimeMillis()
         synchronized(lock) {
+            if (primed) return
             store.clear()
             for (raw in stored) {
                 val parsed = runCatching { json.decodeFromString<StoredCookie>(raw) }.getOrNull()
@@ -54,6 +57,7 @@ class JamarrCookieJar(
                 store.getOrPut(parsed.domain) { mutableListOf() }.add(builder.build())
             }
         }
+        primed = true
     }
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
@@ -94,6 +98,7 @@ class JamarrCookieJar(
 
     suspend fun clear() {
         synchronized(lock) { store.clear() }
+        primed = false
         settingsStore.saveCookies(emptyList())
     }
 

--- a/android/app/src/main/java/com/jamarr/android/playback/JamarrPlaybackService.kt
+++ b/android/app/src/main/java/com/jamarr/android/playback/JamarrPlaybackService.kt
@@ -16,14 +16,15 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import com.jamarr.android.JamarrApplication
 import com.jamarr.android.MainActivity
 import com.jamarr.android.auth.SettingsStore
 import com.jamarr.android.auth.TokenHolder
 import com.jamarr.android.data.JamarrApiClient
-import com.jamarr.android.data.JamarrCookieJar
 import com.jamarr.android.data.SearchTrack
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +34,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
 @OptIn(markerClass = [UnstableApi::class])
@@ -56,14 +56,26 @@ class JamarrPlaybackService : MediaLibraryService() {
     override fun onCreate() {
         super.onCreate()
 
+        val app = applicationContext as JamarrApplication
+        tokenHolder = app.tokenHolder
+        val cookieJar = app.cookieJar
         settingsStore = SettingsStore(applicationContext)
-        tokenHolder = TokenHolder()
-        val cookieJar = JamarrCookieJar(settingsStore)
+
+        val authFailed = AtomicBoolean(false)
+
         apiClient = JamarrApiClient(
             tokenHolder = tokenHolder,
             cookieJar = cookieJar,
             onTokenRefreshed = { token -> settingsStore.saveAccessToken(token) },
-            onRefreshFailed = { settingsStore.clearAccessToken() },
+            onRefreshFailed = {
+                settingsStore.clearAccessToken()
+                authFailed.set(true)
+            },
+            onForceLogout = {
+                settingsStore.clearAccessToken()
+                cookieJar.clear()
+                authFailed.set(true)
+            },
         )
 
         val clientId = runBlocking {
@@ -77,7 +89,6 @@ class JamarrPlaybackService : MediaLibraryService() {
         serviceScope.launch {
             settingsStore.observeSession().collectLatest { session ->
                 serverUrl.set(session.serverUrl)
-                tokenHolder.set(session.accessToken)
             }
         }
 
@@ -108,7 +119,8 @@ class JamarrPlaybackService : MediaLibraryService() {
             var lastReportedMediaId: String? = null
             while (true) {
                 val url = serverUrl.get()
-                if (url.isNotBlank() && clientId.isNotBlank()) {
+                val token = tokenHolder.get()
+                if (url.isNotBlank() && clientId.isNotBlank() && token.isNotBlank() && !authFailed.get()) {
                     val qKey = queueKey(player)
                     if (qKey != null && qKey != lastReportedQueueKey) {
                         lastReportedQueueKey = qKey
@@ -122,7 +134,7 @@ class JamarrPlaybackService : MediaLibraryService() {
                                 serviceScope.launch(Dispatchers.IO) {
                                     runCatching {
                                         withTimeout(5000) {
-                                            apiClient.streamUrl(url, tokenHolder.get(), tid)
+                                            apiClient.streamUrl(url, token, tid)
                                         }
                                     }.onSuccess { resolved ->
                                         streamUrlCache[tid] = CachedStreamUrl(

--- a/android/app/src/main/java/com/jamarr/android/ui/JamarrViewModel.kt
+++ b/android/app/src/main/java/com/jamarr/android/ui/JamarrViewModel.kt
@@ -7,11 +7,10 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.jamarr.android.BuildConfig
+import com.jamarr.android.JamarrApplication
 import com.jamarr.android.auth.SettingsStore
-import com.jamarr.android.auth.TokenHolder
 import com.jamarr.android.data.HomeContent
 import com.jamarr.android.data.JamarrApiClient
-import com.jamarr.android.data.JamarrCookieJar
 import com.jamarr.android.data.PlayerStateResponse
 import com.jamarr.android.data.Renderer
 import com.jamarr.android.data.SearchResponse
@@ -31,14 +30,18 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class JamarrViewModel(application: Application) : AndroidViewModel(application) {
+    private val app = application as JamarrApplication
     private val settingsStore = SettingsStore(application)
-    val tokenHolder = TokenHolder()
-    private val cookieJar = JamarrCookieJar(settingsStore)
+    val tokenHolder = app.tokenHolder
+    private val cookieJar = app.cookieJar
     val apiClient = JamarrApiClient(
         tokenHolder = tokenHolder,
         cookieJar = cookieJar,
         onTokenRefreshed = { newToken -> settingsStore.saveAccessToken(newToken) },
         onRefreshFailed = {
+            settingsStore.clearAccessToken()
+        },
+        onForceLogout = {
             settingsStore.clearAccessToken()
             cookieJar.clear()
         },

--- a/android/deploy.sh
+++ b/android/deploy.sh
@@ -6,30 +6,37 @@ cd "$(dirname "$0")"
 GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/gradle-cache}"
 export GRADLE_USER_HOME
 
-JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk}"
+if [ -z "${JAVA_HOME:-}" ]; then
+  if command -v java >/dev/null 2>&1; then
+    JAVA_HOME="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
+  fi
+fi
 export JAVA_HOME
 
-if ! command -v adb >/dev/null 2>&1; then
-  echo "adb is not installed or is not on PATH." >&2
-  exit 1
+if [ $# -gt 0 ]; then
+  ./gradlew "$@"
+  exit 0
 fi
 
-device_count="$(
-  adb devices |
-    awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }'
-)"
-
-if [ "$device_count" -eq 0 ]; then
-  echo "No authorized Android device found." >&2
-  echo "Connect a phone, enable USB debugging, and accept the authorization prompt." >&2
-  adb devices -l >&2
-  exit 1
+has_device=false
+if command -v adb >/dev/null 2>&1; then
+  device_count="$(
+    adb devices 2>/dev/null |
+      awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }'
+  )"
+  if [ "$device_count" -gt 0 ]; then
+    has_device=true
+    if [ "$device_count" -gt 1 ]; then
+      echo "Multiple Android devices connected. Set ANDROID_SERIAL and retry." >&2
+      adb devices -l >&2
+      exit 1
+    fi
+  fi
 fi
 
-if [ "$device_count" -gt 1 ]; then
-  echo "Multiple Android devices are connected. Set ANDROID_SERIAL and retry." >&2
-  adb devices -l >&2
-  exit 1
+if $has_device; then
+  ./gradlew :app:installDebug
+else
+  echo "No device connected — running assembleDebug (build only)." >&2
+  ./gradlew :app:assembleDebug
 fi
-
-./gradlew :app:installDebug "$@"


### PR DESCRIPTION
## Summary

- ViewModel and PlaybackService had separate TokenHolder/CookieJar instances, causing split-brain refresh failures
- Unified via JamarrApplication singleton holding shared instances
- Global refresh lock prevents concurrent refreshes across instances
- Failure counter forces logout after 2 consecutive refresh failures
- deploy.sh auto-detects JAVA_HOME and falls back to assembleDebug when no device connected