### PR TITLE
fix(server): upnp discovery backoff and monitor churn

### DIFF
--- a/app/api/player.py
+++ b/app/api/player.py
@@ -25,6 +25,7 @@ from app.models.player import (
 from app.services.player.globals import (
     playback_monitors,
     monitor_start_times,
+    _monitor_restart_history,
 )
 from app.services.player.state import (
     get_renderer_state_db,
@@ -83,14 +84,20 @@ async def get_player_state(client_id: str = Depends(get_client_id)):
         # UPnP uses the legacy polling monitor. Event-capable backends like Cast
         # update state through the renderer orchestrator callback path.
         if renderer_id.startswith("upnp:"):
-            # For UPnP devices, we might want to check if monitor is running
             if state["is_playing"]:
                 if udn not in playback_monitors or playback_monitors[udn].done():
-                    # Only restart if it's been at least 5 seconds since last start
                     now = time.time()
                     last_start = monitor_start_times.get(udn, 0)
-                    if now - last_start > 5 and not _is_monitor_starting(udn):
+                    # Throttle rapid restarts: if 3+ restarts in 2 min, wait 60s
+                    history = _monitor_restart_history.setdefault(udn, [])
+                    history[:] = [t for t in history if now - t < 120]
+                    if len(history) >= 3:
+                        if now - last_start < 60:
+                            continue
+                        history.clear()
+                    if now - last_start > 30 and not _is_monitor_starting(udn):
                         logger.info(f"[Player] Auto-restarting monitor for {udn}")
+                        history.append(now)
                         start_monitor_task(udn)
         elif not renderer_id.startswith("local:"):
             state = await renderer_orchestrator.sync_status(db, renderer_id, udn, state)

--- a/app/services/player/globals.py
+++ b/app/services/player/globals.py
@@ -7,3 +7,5 @@ monitor_start_times: Dict[str, float] = {}  # Track when monitors were last star
 # Track when we last started a new track to prevent false "track finished" detection during transitions
 last_track_start_time: Dict[str, float] = {}
 monitor_starting: Dict[str, float] = {}
+# Track rapid restart attempts: udn -> [(start_time, count_window_start)]
+_monitor_restart_history: Dict[str, list] = {}

--- a/app/services/player/monitor.py
+++ b/app/services/player/monitor.py
@@ -52,6 +52,7 @@ async def monitor_upnp_playback(udn: str):
 
     was_playing = False  # Initialize to prevent UnboundLocalError
     consecutive_errors = 0
+    error_started_at = 0.0  # when the first error in the current streak occurred
     try:
         while True:
             # 1. Fetch position & transport from UPnP
@@ -61,19 +62,26 @@ async def monitor_upnp_playback(udn: str):
                 transport_state = await upnp.get_transport_info(udn)
                 logger.info(f"[Player] Monitor {udn}: Got pos={rel_time}, state={transport_state}")
                 consecutive_errors = 0  # Reset on success
+                error_started_at = 0.0
             except Exception as e:
+                now = time.time()
                 consecutive_errors += 1
-                logger.error(
-                    f"[Player] Monitor {udn}: Error fetching state (attempt {consecutive_errors}/10): {e}",
-                    exc_info=True,
-                )
-                if consecutive_errors > 10:
+                if error_started_at == 0.0:
+                    error_started_at = now
+                error_duration = now - error_started_at
+                # Kill only after 5 minutes of continuous errors
+                if error_duration > 300:
                     logger.error(
-                        f"[Player] Monitor {udn}: Too many consecutive errors, stopping"
+                        f"[Player] Monitor {udn}: Errors persisted {error_duration:.0f}s, stopping"
                     )
                     break
-                # Use last known values and continue
-                await asyncio.sleep(1)
+                # Exponential backoff: 1s → 2s → 4s → 8s → 16s → cap 30s
+                backoff = min(1 << (consecutive_errors - 1), 30)
+                logger.error(
+                    f"[Player] Monitor {udn}: Error fetching state (#{consecutive_errors}, "
+                    f"backoff {backoff}s, streak {error_duration:.0f}s): {e}"
+                )
+                await asyncio.sleep(backoff)
                 continue
 
             # 2. Update DB

--- a/app/services/upnp/discovery.py
+++ b/app/services/upnp/discovery.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional
 import asyncio
 import logging
+import time
 import aiohttp
 from urllib.parse import urlparse
 from async_upnp_client.search import async_search
@@ -15,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 SSDP_TARGET_MEDIA_RENDERER = "urn:schemas-upnp-org:device:MediaRenderer:1"
 
+# Cooldown steps for persistently unreachable renderers (seconds).
+_FAILURE_COOLDOWN_STEPS = [120, 300, 900, 3600]
+
 class UPnPDiscovery:
     def __init__(self, manager):
         self.manager = manager
@@ -23,6 +27,8 @@ class UPnPDiscovery:
         self.is_scanning_subnet = False
         self.scan_msg = ""
         self.scan_progress = 0
+        # location -> {"failures": int, "cooldown_until": float}
+        self._failure_state: Dict[str, dict] = {}
 
     def start_background_scan(self):
         """Start background discovery loop."""
@@ -82,8 +88,12 @@ class UPnPDiscovery:
                 search_target=SSDP_TARGET_MEDIA_RENDERER,
             )
 
-            # Process discovered devices
+            # Process discovered devices, skipping those in cooldown
+            now = time.time()
             for location in discovered_locations:
+                state = self._failure_state.get(location)
+                if state and state.get("cooldown_until", 0) > now:
+                    continue
                 await self._add_renderer(location)
 
             self.manager.log(f"Discovery complete. Found {len(self.manager.renderers)} renderer(s)")
@@ -201,9 +211,11 @@ class UPnPDiscovery:
                 self.manager.renderers[udn] = renderer_info
 
             self.manager.log(f"Added renderer: {renderer_info['friendly_name']} ({udn})")
+            self._failure_state.pop(location, None)  # success resets failure tracking
 
         except Exception as e:
             logger.error(f"Error adding renderer from {location}: {e}")
+            self._track_failure(location)
             self.manager.log(f"Error adding renderer: {e}")
 
     async def load_persisted_renderers(self):
@@ -224,7 +236,10 @@ class UPnPDiscovery:
                 location = r.get("location") or r.get("location_url")
                 if location:
                     r["location"] = location
-                
+                    state = self._failure_state.get(location)
+                    if state and state.get("cooldown_until", 0) > time.time():
+                        continue
+
                 if await self.verify_device(r):
                     self.manager.renderers[r["udn"]] = r
                     if r.get("location"):
@@ -232,6 +247,19 @@ class UPnPDiscovery:
                             await self._add_renderer(r["location"])
                         except Exception as e:
                             logger.debug(f"Could not recreate DMR for {r['udn']}: {e}")
+
+    def _track_failure(self, location: str) -> None:
+        now = time.time()
+        entry = self._failure_state.get(location)
+        if entry is None:
+            self._failure_state[location] = {"failures": 1, "cooldown_until": now + _FAILURE_COOLDOWN_STEPS[0]}
+            return
+        failures = entry["failures"] + 1
+        step_idx = min(failures, len(_FAILURE_COOLDOWN_STEPS)) - 1
+        self._failure_state[location] = {
+            "failures": failures,
+            "cooldown_until": now + _FAILURE_COOLDOWN_STEPS[step_idx],
+        }
 
     async def verify_device(self, r: Dict[str, Any]) -> bool:
         """Quick check if device is reachable."""


### PR DESCRIPTION
## Summary

- Dead UPNP renderers (unreachable link-local addresses) now get increasing discovery cooldowns instead of timeout-spamming the log every 30 seconds
- Monitor error handling uses exponential backoff instead of dying after 10 failures; only kills after 5 minutes of continuous errors
- Auto-restart cooldown raised from 5s to 30s, with rapid-restart throttling