### PR TITLE
fix(charts): exclude singles, always prefer album for album-chart match

### DIFF
--- a/app/charts.py
+++ b/app/charts.py
@@ -287,6 +287,8 @@ async def enrich_entries(entries: List[ChartEntry]):
                             for candidate in data.get("releases", []):
                                 rg = candidate.get("release-group") or {}
                                 primary_type = (rg.get("primary-type") or "").lower()
+                                if primary_type == "single":
+                                    continue
                                 score = _score_candidate(entry, candidate)
                                 hit = {
                                     "score": score,
@@ -303,13 +305,11 @@ async def enrich_entries(entries: List[ChartEntry]):
                         logger.warning(f"Chart enrich: MB error for '{entry.title}' ({query}): {e}")
                         continue
 
-                # Prefer album, but let a clearly-better non-album (EP/Single) win when
-                # it scores noticeably higher (exact title match beating a near-miss album).
+                # Album chart: always prefer album when one matches; fall back to
+                # EP/other only if no album candidate cleared the threshold.
                 album_score = best_album["score"] if best_album else 0
                 other_score = best_other["score"] if best_other else 0
-                if best_other and other_score >= 75 and other_score >= album_score + 3:
-                    best = best_other
-                elif best_album and album_score > 60:
+                if best_album and album_score > 60:
                     best = best_album
                 elif best_other and other_score > 75:
                     best = best_other
@@ -340,6 +340,8 @@ async def enrich_entries(entries: List[ChartEntry]):
                                 data = resp.json()
                                 for rg in data.get("release-groups", []):
                                     ptype = (rg.get("primary-type") or "").lower()
+                                    if ptype == "single":
+                                        continue
                                     score = _score_rg_candidate(entry, rg)
                                     hit = {"score": score, "rg_id": rg.get("id", "")}
                                     if ptype == "album" or not ptype:
@@ -354,9 +356,7 @@ async def enrich_entries(entries: List[ChartEntry]):
 
                     album_score = best_album["score"] if best_album else 0
                     other_score = best_other["score"] if best_other else 0
-                    if best_other and other_score >= 75 and other_score >= album_score + 3:
-                        best = best_other
-                    elif best_album and album_score > 60:
+                    if best_album and album_score > 60:
                         best = best_album
                     elif best_other and other_score > 75:
                         best = best_other


### PR DESCRIPTION
## Summary
- UK album chart enrichment was picking single release-groups over the correct album when single re-releases had a worldwide (`XW`) country boost the original album release (often US) lacked.
- Example: Noah Kahan "The Great Divide" matched single RG `1d8b85bb` instead of album RG `09d6c4af`; MUNA "Dancing on the Wall" matched single RG `a7398711` instead of album RG `593c32c9`.
- Fix: skip `primary-type=single` in both Phase 2 (release) and Phase 3 (release-group) candidate loops, and remove the non-album override path so any album scoring >60 wins outright.

## Test plan
- [ ] Deploy to prod, trigger chart refresh
- [ ] Verify `chart_album.release_group_mbid` for "DANCING ON THE WALL" = `593c32c9-1532-4d97-bcdd-9e1e91b0a4ce`
- [ ] Verify `chart_album.release_group_mbid` for "THE GREAT DIVIDE" = `09d6c4af-2545-468e-8b44-4d5eb3e9aa85`
- [ ] Spot-check that compilations / EPs still match correctly when no album exists