### PR TITLE
fix: resolve all open security alerts (PyJWT migration, error leak, stale CodeQL)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python, javascript-typescript]
+        language: [actions, python, javascript-typescript]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -42,6 +42,7 @@ jobs:
           TEST_DB_PASSWORD=jamarr_test_secret
           LASTFM_API_KEY=dummy_lastfm_key
           LASTFM_SHARED_SECRET=dummy_lastfm_secret
+          JWT_SECRET_KEY=dummy_jwt_secret_at_least_32_bytes_long_for_hs256
           EOF
 
       - name: Make scripts executable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ app/                 backend (Python)
     player/ renderer/ upnp/
   matching/          fuzzy match (rapidfuzz) for charts/metadata
   media/             artwork / media handling
-  auth.py auth_tokens.py security.py    JWT auth (python-jose, argon2, slowapi)
+  auth.py auth_tokens.py security.py    JWT auth (pyjwt, argon2, slowapi)
   db.py config.py logging_conf.py scheduler.py charts.py lastfm*.py playlist.py upnp.py
 web/src/             SvelteKit: routes/ (album,artist,charts,discovery,history,
                      login,playlists,queue,renderers,settings) + lib/

--- a/app/api/lastfm.py
+++ b/app/api/lastfm.py
@@ -283,9 +283,10 @@ async def sync_scrobbles(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Last.fm account not connected. Please connect your Last.fm account in settings.",
             )
+        logger.exception("Last.fm sync failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(exc),
+            detail="Last.fm sync failed. Check server logs for details.",
         )
 
 

--- a/app/auth_tokens.py
+++ b/app/auth_tokens.py
@@ -9,8 +9,8 @@ import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+import jwt
 from fastapi import HTTPException, status
-from jose import JWTError, jwt
 
 
 # JWT Configuration from environment
@@ -147,10 +147,15 @@ def verify_stream_token(token: str, track_id: int) -> dict:
             issuer=settings["issuer"],
             audience=settings["audience"],
         )
-    except JWTError as e:
+    except jwt.ExpiredSignatureError:
+        detail = "Stream token has expired"
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
         detail = "Invalid stream token"
-        if "expired" in str(e).lower():
-            detail = "Stream token has expired"
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=detail,
@@ -191,18 +196,29 @@ def verify_access_token(token: str) -> dict:
             audience=settings["audience"],
         )
         return payload
-    except JWTError as e:
-        # Handle specific JWT errors
-        error_msg = str(e).lower()
-        if "expired" in error_msg:
-            detail = "Access token has expired"
-        elif "signature" in error_msg:
-            detail = "Invalid token signature"
-        elif "issuer" in error_msg or "audience" in error_msg:
-            detail = "Invalid token issuer or audience"
-        else:
-            detail = "Invalid access token"
-        
+    except jwt.ExpiredSignatureError:
+        detail = "Access token has expired"
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidSignatureError:
+        detail = "Invalid token signature"
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except (jwt.InvalidIssuerError, jwt.InvalidAudienceError):
+        detail = "Invalid token issuer or audience"
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
+        detail = "Invalid access token"
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=detail,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "rapidfuzz",
     "pylast>=7.0.1",
     "croniter",
-    "python-jose[cryptography]",
+    "pyjwt[crypto]",
     "slowapi",
     "pychromecast>=14.0.0",
     "zeroconf>=0.130.0",

--- a/tests/api/test_stream.py
+++ b/tests/api/test_stream.py
@@ -6,7 +6,7 @@ import wave
 from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
 
-from jose import jwt
+import jwt
 
 from app.services.stream_profiles import (
     cleanup_stream_cache,
@@ -117,7 +117,7 @@ async def test_stream_url_cast_token_uses_renderer_policy(auth_client: AsyncClie
 
     assert response.status_code == 200
     token = parse_qs(urlparse(response.json()["url"]).query)["token"][0]
-    claims = jwt.get_unverified_claims(token)
+    claims = jwt.decode(token, options={"verify_signature": False})
     issued_at = datetime.fromtimestamp(claims["iat"], tz=timezone.utc)
     expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
     assert (expires_at - issued_at).total_seconds() == 1800
@@ -142,7 +142,7 @@ async def test_stream_url_quality_claims(auth_client: AsyncClient, db, stream_da
     assert data["stream_mime_type"] == "audio/flac"
     assert data["original_quality_label"] == "FLAC 24 bit 96 kHz"
     token = parse_qs(urlparse(data["url"]).query)["token"][0]
-    claims = jwt.get_unverified_claims(token)
+    claims = jwt.decode(token, options={"verify_signature": False})
     assert claims["stream_quality"] == "flac_16_48"
 
 

--- a/tests/auth/test_jwt_tokens.py
+++ b/tests/auth/test_jwt_tokens.py
@@ -2,7 +2,7 @@
 import os
 from datetime import timedelta, datetime, timezone
 import pytest
-from jose import jwt
+import jwt
 
 
 # We'll import these after creating the module
@@ -10,7 +10,7 @@ from jose import jwt
 
 
 # Test configuration
-TEST_SECRET = "test-secret-key-for-jwt-testing"
+TEST_SECRET = "test-secret-key-for-jwt-testing-0"
 TEST_ISSUER = "jamarr-test"
 TEST_AUDIENCE = "jamarr-api-test"
 
@@ -39,7 +39,7 @@ def test_create_access_token_valid_structure():
     token = create_access_token(user_id=user_id, expires_delta=expires_delta)
     
     # Decode without verification to inspect structure
-    unverified = jwt.get_unverified_claims(token)
+    unverified = jwt.decode(token, options={"verify_signature": False})
     
     assert "sub" in unverified
     assert unverified["sub"] == str(user_id)

--- a/tests/auth/test_stream_token_phase0.py
+++ b/tests/auth/test_stream_token_phase0.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timezone
 
-from jose import jwt
+import jwt
 
 
 def test_phase0_stream_token_default_ttl_is_300_seconds():
     from app.auth_tokens import create_stream_token
 
     token = create_stream_token(track_id=901, user_id=42)
-    claims = jwt.get_unverified_claims(token)
+    claims = jwt.decode(token, options={"verify_signature": False})
 
     issued_at = datetime.fromtimestamp(claims["iat"], tz=timezone.utc)
     expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)

--- a/uv.lock
+++ b/uv.lock
@@ -508,18 +508,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -707,8 +695,8 @@ dependencies = [
     { name = "pillow" },
     { name = "pycares" },
     { name = "pychromecast" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pylast" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
@@ -747,8 +735,8 @@ requires-dist = [
     { name = "pillow" },
     { name = "pycares", specifier = ">=5.0.0" },
     { name = "pychromecast", specifier = ">=14.0.0" },
+    { name = "pyjwt", extras = ["crypto"] },
     { name = "pylast", specifier = ">=7.0.1" },
-    { name = "python-jose", extras = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
@@ -1183,15 +1171,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
 name = "pycares"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1315,6 +1294,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pylast"
 version = "7.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1398,25 +1391,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1522,18 +1496,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears everything on the security tab: the last dependabot alert and all 4 code-scanning alerts.

## fix(auth): python-jose → PyJWT
- Removes `python-jose` (barely maintained) and its hard dep `python-ecdsa`, which carries an **unfixable** high-severity Minerva timing-attack advisory (vulnerable range `>= 0`; maintainers consider side channels out of scope). Closes the last open dependabot alert.
- `pyjwt[crypto] 2.13.0`; `ecdsa` and `rsa` drop out of the lockfile entirely.
- encode/decode call sites unchanged; error-message sniffing replaced with typed exceptions (`ExpiredSignatureError`, `InvalidSignatureError`, `InvalidIssuerError`/`InvalidAudienceError`). Same 401 details as before.
- PyJWT enforces RFC 7518 min HMAC key length (32 bytes for HS256): test secret lengthened, CI dummy `.env` given a proper-length `JWT_SECRET_KEY`.

## fix(api): lastfm sync error leak (CodeQL #86, py/stack-trace-exposure)
`POST /api/lastfm/sync` 500 handler returned `str(exc)` to clients, leaking internal state (e.g. "LASTFM_API_KEY not configured"). Now logs server-side, returns generic detail.

## ci(codeql): add `actions` language (closes stale alerts #44/#45/#46)
The 3 missing-workflow-permissions alerts were fixed on main in 55a5912, but nothing re-analyzes the `actions` language so they never closed. Matrix now `[actions, python, javascript-typescript]`; first main analysis closes them.

## Verified
- `./test.sh` — 355 backend passed (1 skipped), 11 TUI passed
- `./lint.sh` — clean

## Post-merge action for ops
Rotate the production `JWT_SECRET_KEY` — current one is 22 chars, below the 32-byte HS256 minimum (PyJWT now warns). `python -c 'import secrets; print(secrets.token_urlsafe(32))'`. Invalidates all active sessions.