### PR TITLE
fix(api): keep exception text out of lastfm sync client logs

### DIFF
--- a/app/api/lastfm.py
+++ b/app/api/lastfm.py
@@ -473,10 +473,9 @@ async def sync_scrobbles_for_user(
                     page += 1
                     if sleep_between_pages > 0:
                         await asyncio.sleep(sleep_between_pages)
-                except Exception as e:
-                    error_msg = f"Error fetching page {page}: {str(e)}"
-                    add_log(error_msg)
-                    logger.error(error_msg, exc_info=True)
+                except Exception:
+                    logger.error(f"Error fetching page {page}", exc_info=True)
+                    add_log(f"Error fetching page {page}; stopped fetching. See server logs.")
                     break
 
         log_msg = f"Fetched {fetched} new scrobbles"


### PR DESCRIPTION
Second half of CodeQL #86 (`py/stack-trace-exposure`). PR #206 fixed the 500 detail path; the alert actually pointed at the 200 path — page-fetch errors appended `str(e)` to the sync log list returned to clients in the response body (`app/api/lastfm.py`, `add_log`), also surfaced via the sync manager.

Now: exception logged server-side with traceback, client log gets a generic "Error fetching page N; stopped fetching. See server logs." line.

Verified: `./test.sh tests/api` — 96 passed; ruff clean.

Closes the last open code-scanning alert.