### PR TITLE
fix: 404 probe paths in SPA fallback; back off unreachable UPnP renderers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Backend tests need the test DB stack (`docker-compose.test.yml`); `test.sh` brin
 - UPnP needs host networking — discovery won't work in bridged containers.
 - `HOST_IP` auto-derived in `dev.sh`/`deploy.sh` via route lookup; override by exporting it.
 - Frontend dev caches (`web/.svelte-kit`, `web/.vite`) are cleared on `dev.sh` start.
+- New top-level route under `web/src/routes/` must also be added to
+  `_SPA_ROUTE_PREFIXES` in `app/main.py`, or the backend 404s it.
 - `android/test.sh` defaults `ANDROID_HOME=/opt/android-sdk` and caps gradle/kotlin
   heaps when <4 GiB memory available; instrumentation tests only run with a device attached.
 

--- a/app/main.py
+++ b/app/main.py
@@ -126,6 +126,25 @@ _BLOCKED_PATH_PATTERNS = re.compile(
     """
 )
 
+# Top-level paths owned by the SvelteKit client router. Unknown paths that are
+# not real files in web/build get a 404 instead of the index shell, so probes
+# (/.env_production, /exceptions.zip, ...) can't elicit a 200. Keep in sync
+# with the top-level directories under web/src/routes/.
+_SPA_ROUTE_PREFIXES = frozenset({
+    "",
+    "album",
+    "artist",
+    "artists",
+    "charts",
+    "discovery",
+    "history",
+    "login",
+    "playlists",
+    "queue",
+    "renderers",
+    "settings",
+})
+
 
 @app.get("/{path:path}")
 async def spa(path: str):
@@ -148,6 +167,9 @@ async def spa(path: str):
         raise HTTPException(status_code=404, detail="Not Found")
     if os.path.isfile(target):
         return FileResponse(target)
+
+    if path.strip("/").split("/", 1)[0] not in _SPA_ROUTE_PREFIXES:
+        raise HTTPException(status_code=404, detail="Not Found")
 
     index_path = build_dir / "index.html"
     if index_path.exists():

--- a/app/services/upnp/discovery.py
+++ b/app/services/upnp/discovery.py
@@ -19,6 +19,12 @@ SSDP_TARGET_MEDIA_RENDERER = "urn:schemas-upnp-org:device:MediaRenderer:1"
 # Cooldown steps for persistently unreachable renderers (seconds).
 _FAILURE_COOLDOWN_STEPS = [120, 300, 900, 3600]
 
+# After this many consecutive failures the renderer is suspended: probed at
+# most every _SUSPENDED_RETRY_INTERVAL, or immediately if it re-announces with
+# a new BOOTID (i.e. its UPnP stack actually restarted).
+_SUSPEND_AFTER_FAILURES = 5
+_SUSPENDED_RETRY_INTERVAL = 6 * 3600
+
 class UPnPDiscovery:
     def __init__(self, manager):
         self.manager = manager
@@ -27,7 +33,8 @@ class UPnPDiscovery:
         self.is_scanning_subnet = False
         self.scan_msg = ""
         self.scan_progress = 0
-        # location -> {"failures": int, "cooldown_until": float}
+        # location -> {"failures": int, "cooldown_until": float,
+        #              "bootid": Optional[str], "suspended": bool}
         self._failure_state: Dict[str, dict] = {}
 
     def start_background_scan(self):
@@ -68,7 +75,7 @@ class UPnPDiscovery:
         """
         await self.manager._ensure_session()
         self.manager.log(f"Starting UPnP discovery (timeout={timeout}s)...")
-        discovered_locations = []
+        discovered: Dict[str, Optional[str]] = {}
 
         async def search_callback(headers: CaseInsensitiveDict):
             """Callback for each discovered device."""
@@ -77,8 +84,8 @@ class UPnPDiscovery:
 
             # Filter for MediaRenderer devices
             if location and st and "MediaRenderer" in st:
-                if location not in discovered_locations:
-                    discovered_locations.append(location)
+                if location not in discovered:
+                    discovered[location] = headers.get("BOOTID.UPNP.ORG")
 
         try:
             # Perform search with callback
@@ -89,12 +96,10 @@ class UPnPDiscovery:
             )
 
             # Process discovered devices, skipping those in cooldown
-            now = time.time()
-            for location in discovered_locations:
-                state = self._failure_state.get(location)
-                if state and state.get("cooldown_until", 0) > now:
+            for location, bootid in discovered.items():
+                if not self._should_attempt(location, bootid):
                     continue
-                await self._add_renderer(location)
+                await self._add_renderer(location, bootid=bootid)
 
             self.manager.log(f"Discovery complete. Found {len(self.manager.renderers)} renderer(s)")
 
@@ -102,7 +107,7 @@ class UPnPDiscovery:
             logger.error(f"Discovery error: {e}")
             self.manager.log(f"Discovery error: {e}")
 
-    async def _add_renderer(self, location: str):
+    async def _add_renderer(self, location: str, bootid: Optional[str] = None):
         """
         Add or update a renderer from its description URL.
         """
@@ -211,12 +216,14 @@ class UPnPDiscovery:
                 self.manager.renderers[udn] = renderer_info
 
             self.manager.log(f"Added renderer: {renderer_info['friendly_name']} ({udn})")
-            self._failure_state.pop(location, None)  # success resets failure tracking
+            prior = self._failure_state.pop(location, None)  # success resets failure tracking
+            if prior:
+                logger.info(
+                    f"Renderer at {location} reachable again after {prior['failures']} failure(s)"
+                )
 
         except Exception as e:
-            logger.error(f"Error adding renderer from {location}: {e}")
-            self._track_failure(location)
-            self.manager.log(f"Error adding renderer: {e}")
+            self._track_failure(location, e, bootid)
 
     async def load_persisted_renderers(self):
         """Load previously discovered renderers from database."""
@@ -236,8 +243,7 @@ class UPnPDiscovery:
                 location = r.get("location") or r.get("location_url")
                 if location:
                     r["location"] = location
-                    state = self._failure_state.get(location)
-                    if state and state.get("cooldown_until", 0) > time.time():
+                    if not self._should_attempt(location, None):
                         continue
 
                 if await self.verify_device(r):
@@ -248,17 +254,47 @@ class UPnPDiscovery:
                         except Exception as e:
                             logger.debug(f"Could not recreate DMR for {r['udn']}: {e}")
 
-    def _track_failure(self, location: str) -> None:
+    def _should_attempt(self, location: str, bootid: Optional[str]) -> bool:
+        """Whether a probe of this location is due, given its failure history."""
+        state = self._failure_state.get(location)
+        if state is None:
+            return True
+        if state.get("suspended") and bootid and bootid != state.get("bootid"):
+            # Device re-announced with a new BOOTID: its UPnP stack restarted,
+            # so give it a fresh start.
+            self._failure_state.pop(location, None)
+            return True
+        return state.get("cooldown_until", 0) <= time.time()
+
+    def _track_failure(self, location: str, error: Exception, bootid: Optional[str] = None) -> None:
         now = time.time()
-        entry = self._failure_state.get(location)
-        if entry is None:
-            self._failure_state[location] = {"failures": 1, "cooldown_until": now + _FAILURE_COOLDOWN_STEPS[0]}
-            return
-        failures = entry["failures"] + 1
-        step_idx = min(failures, len(_FAILURE_COOLDOWN_STEPS)) - 1
+        entry = self._failure_state.get(location) or {}
+        failures = entry.get("failures", 0) + 1
+
+        # ERROR on the first failure only; repeats are expected (TVs in standby
+        # answer SSDP but refuse HTTP) and logged at DEBUG.
+        if failures == 1:
+            logger.error(f"Error adding renderer from {location}: {error}")
+            self.manager.log(f"Error adding renderer: {error}")
+        else:
+            logger.debug(f"Error adding renderer from {location} (failure {failures}): {error}")
+
+        suspended = failures >= _SUSPEND_AFTER_FAILURES
+        if suspended:
+            cooldown = _SUSPENDED_RETRY_INTERVAL
+            if not entry.get("suspended"):
+                logger.warning(
+                    f"Renderer at {location} failed {failures} times; probing at most "
+                    f"every {_SUSPENDED_RETRY_INTERVAL // 3600}h until it re-announces"
+                )
+        else:
+            cooldown = _FAILURE_COOLDOWN_STEPS[min(failures, len(_FAILURE_COOLDOWN_STEPS)) - 1]
+
         self._failure_state[location] = {
             "failures": failures,
-            "cooldown_until": now + _FAILURE_COOLDOWN_STEPS[step_idx],
+            "cooldown_until": now + cooldown,
+            "bootid": bootid if bootid is not None else entry.get("bootid"),
+            "suspended": suspended,
         }
 
     async def verify_device(self, r: Dict[str, Any]) -> bool:

--- a/tests/api/test_spa_fallback.py
+++ b/tests/api/test_spa_fallback.py
@@ -1,0 +1,58 @@
+"""SPA fallback must 404 probe paths instead of serving the index shell."""
+
+import pytest
+
+import app.main
+
+
+@pytest.fixture
+def build_dir(tmp_path, monkeypatch):
+    (tmp_path / "index.html").write_text("<!DOCTYPE html><html>jamarr</html>")
+    (tmp_path / "robots.txt").write_text("User-agent: *\n")
+    monkeypatch.setattr(app.main, "build_dir", tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/.env",
+        "/.env_production",
+        "/.env~",
+        "/.env.local.bak",
+        "/exceptions.zip",
+        "/error_log.php",
+        "/wp-admin/setup-config.php",
+        "/phpmyadmin/",
+        "/.git/config",
+        "/backup.sql",
+        "/unknown-toplevel",
+    ],
+)
+async def test_probe_paths_get_404(client, build_dir, path):
+    resp = await client.get(path)
+    assert resp.status_code == 404
+    assert "jamarr" not in resp.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/charts",
+        "/login",
+        "/settings/library",
+        "/album/R.E.M./Murmur",  # route params may contain dots
+        "/artist/some-mbid",
+    ],
+)
+async def test_spa_routes_get_index(client, build_dir, path):
+    resp = await client.get(path)
+    assert resp.status_code == 200
+    assert "jamarr" in resp.text
+
+
+async def test_real_files_in_build_still_served(client, build_dir):
+    resp = await client.get("/robots.txt")
+    assert resp.status_code == 200
+    assert "User-agent" in resp.text

--- a/tests/unit/test_upnp_discovery_backoff.py
+++ b/tests/unit/test_upnp_discovery_backoff.py
@@ -1,0 +1,111 @@
+"""Failure backoff / suspension state machine for UPnP renderer discovery."""
+
+import logging
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.upnp.discovery import (
+    UPnPDiscovery,
+    _FAILURE_COOLDOWN_STEPS,
+    _SUSPEND_AFTER_FAILURES,
+    _SUSPENDED_RETRY_INTERVAL,
+)
+
+LOCATION = "http://192.168.0.31:16854/desc.xml"
+
+
+@pytest.fixture
+def discovery():
+    manager = MagicMock()
+    return UPnPDiscovery(manager)
+
+
+def _fail(discovery, n=1, bootid=None):
+    for _ in range(n):
+        discovery._track_failure(LOCATION, RuntimeError("boom"), bootid)
+
+
+def test_first_failure_logs_error(discovery, caplog):
+    with caplog.at_level(logging.DEBUG, logger="app.services.upnp.discovery"):
+        _fail(discovery)
+    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+    discovery.manager.log.assert_called_once()
+
+
+def test_repeat_failures_log_debug_not_error(discovery, caplog):
+    _fail(discovery)
+    discovery.manager.log.reset_mock()
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="app.services.upnp.discovery"):
+        _fail(discovery)
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG]
+    discovery.manager.log.assert_not_called()
+
+
+def test_cooldown_steps_escalate(discovery):
+    for i, step in enumerate(_FAILURE_COOLDOWN_STEPS):
+        _fail(discovery)
+        state = discovery._failure_state[LOCATION]
+        assert state["failures"] == i + 1
+        assert state["cooldown_until"] == pytest.approx(time.time() + step, abs=5)
+        assert not discovery._should_attempt(LOCATION, None)
+
+
+def test_attempt_allowed_after_cooldown_expires(discovery):
+    _fail(discovery)
+    discovery._failure_state[LOCATION]["cooldown_until"] = time.time() - 1
+    assert discovery._should_attempt(LOCATION, None)
+
+
+def test_suspension_after_max_failures(discovery, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.services.upnp.discovery"):
+        _fail(discovery, n=_SUSPEND_AFTER_FAILURES)
+    state = discovery._failure_state[LOCATION]
+    assert state["suspended"]
+    assert state["cooldown_until"] == pytest.approx(
+        time.time() + _SUSPENDED_RETRY_INTERVAL, abs=5
+    )
+    # Exactly one WARNING at the moment of suspension, not on later failures.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="app.services.upnp.discovery"):
+        _fail(discovery)
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_suspended_device_skipped_until_bootid_changes(discovery):
+    _fail(discovery, n=_SUSPEND_AFTER_FAILURES, bootid="1")
+    assert not discovery._should_attempt(LOCATION, "1")
+    assert not discovery._should_attempt(LOCATION, None)
+    # New BOOTID means the device's UPnP stack restarted: fresh start.
+    assert discovery._should_attempt(LOCATION, "2")
+    assert LOCATION not in discovery._failure_state
+
+
+def test_suspended_device_retried_after_interval(discovery):
+    _fail(discovery, n=_SUSPEND_AFTER_FAILURES, bootid="1")
+    discovery._failure_state[LOCATION]["cooldown_until"] = time.time() - 1
+    assert discovery._should_attempt(LOCATION, "1")
+
+
+def test_bootid_preserved_when_failure_has_none(discovery):
+    _fail(discovery, bootid="1")
+    _fail(discovery, bootid=None)
+    assert discovery._failure_state[LOCATION]["bootid"] == "1"
+
+
+def test_success_reset_makes_next_failure_error_again(discovery, caplog):
+    _fail(discovery, n=3)
+    # _add_renderer pops state on success.
+    discovery._failure_state.pop(LOCATION, None)
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="app.services.upnp.discovery"):
+        _fail(discovery)
+    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+
+
+def test_unknown_location_always_attempted(discovery):
+    assert discovery._should_attempt("http://192.168.0.99:1234/desc.xml", None)


### PR DESCRIPTION
Two fixes from a prod log review.

## SPA fallback: 404 unknown paths (`app/main.py`)

Internet scanners probing `/.env_production`, `/.env~` and `/exceptions.zip` got a 200/206 with the SvelteKit index shell — the blocklist regex didn't cover those variants. Replaced reliance on the blocklist with a whitelist of the top-level routes owned by the client router; anything else that isn't a real file in `web/build` now 404s.

- Route params with dots (`/album/R.E.M./Murmur`) still reach the SPA — only the first path segment is checked.
- Real files in the build (e.g. `robots.txt`) still served.
- AGENTS.md gotcha added: new top-level route under `web/src/routes/` needs a `_SPA_ROUTE_PREFIXES` entry.

## UPnP discovery: quiet + suspend dead renderers (`app/services/upnp/discovery.py`)

Google TVs in standby answer SSDP multicast but refuse the HTTP description fetch, so discovery logged an ERROR every cooldown expiry forever, and any transient success reset the backoff to 2 minutes.

- ERROR only on the first consecutive failure; repeats at DEBUG, recovery at INFO. A device that recovers then re-fails gets ERROR again.
- After 5 consecutive failures the renderer is suspended: probed at most every 6h, with a single WARNING at suspension.
- Escape hatch: a fresh SSDP announce with a new `BOOTID.UPNP.ORG` (UPnP stack actually restarted) resets the state immediately, so a TV waking from standby reconnects without waiting.
- 6h floor instead of infinite suspension protects devices that never send BOOTID (UPnP 1.0).

## Tests

- `tests/api/test_spa_fallback.py` — 18 cases: probes 404, SPA routes get the index, real files served.
- `tests/unit/test_upnp_discovery_backoff.py` — 10 cases covering the backoff state machine.

Full suite: 383 backend + 11 TUI passed; lint clean.