### PR TITLE
feat(charts): manual MusicBrainz release-group override per chart entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ Backend tests need the test DB stack (`docker-compose.test.yml`); `test.sh` brin
 ## Conventions
 
 - Python: ruff (config in `pyproject.toml` / `lint.sh`). Async-first (asyncpg, httpx, aiofiles).
-- DB changes = new `migrations/NNN_*.sql`, never edit old ones. Update `docs/DATABASE_SCHEMA.md`.
+- DB changes = new `migrations/NNN_*.sql` (existing installs) **and** the matching
+  DDL in `app/db.py` `init_db` (fresh installs + tests). Never edit old migrations.
+  Schema docs are generated (`docs/reference/schema/`) — don't hand-edit.
 - Config: secrets in `.env` (see `.env.example`); non-secret app config in `config.yaml`.
 - Commits: Conventional Commits (`feat(scope):`, `fix(charts):`, `chore(ci):`). **No AI co-author/attribution trailers.**
 - Ports (dev): API 8111, Vite 5173, Postgres 8110, CloudBeaver 8978.

--- a/app/api/charts.py
+++ b/app/api/charts.py
@@ -1,6 +1,7 @@
+import re
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.charts import refresh_chart_task
@@ -32,6 +33,7 @@ class ChartAlbum(BaseModel):
     artist_mbid: Optional[str] = None
     art_sha1: Optional[str] = None
     musicbrainz_url: Optional[str] = None
+    overridden: bool = False
 
 @router.get("", response_model=List[ChartAlbum])
 async def get_chart():
@@ -58,7 +60,8 @@ async def get_chart():
                 a.title as local_title,
                 a.artist_name as local_artist,
                 a.artist_mbid as artist_mbid,
-                art.sha1 as art_sha1
+                art.sha1 as art_sha1,
+                (o.release_group_mbid IS NOT NULL) as overridden
             FROM chart_album c
             LEFT JOIN LATERAL (
                 SELECT a.*, ar.name as artist_name, aa.artist_mbid as artist_mbid
@@ -73,6 +76,8 @@ async def get_chart():
                 LIMIT 1
             ) a ON TRUE
             LEFT JOIN artwork art ON a.artwork_id = art.id
+            LEFT JOIN chart_match_override o
+                ON lower(o.artist) = lower(c.artist) AND lower(o.title) = lower(c.title)
             ORDER BY c.position ASC
         """
         rows = await conn.fetch(query)
@@ -90,3 +95,73 @@ async def get_chart():
 async def refresh_chart():
     await refresh_chart_task()
     return {"status": "refreshed"}
+
+
+_MBID_RE = re.compile(
+    r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", re.IGNORECASE
+)
+
+
+class ChartOverride(BaseModel):
+    artist: str
+    title: str
+    # Bare release-group MBID or any MusicBrainz URL containing one.
+    release_group_mbid: str
+
+
+class ChartOverrideKey(BaseModel):
+    artist: str
+    title: str
+
+
+@router.put("/override", dependencies=[Depends(get_current_admin_user_jwt)])
+async def set_chart_override(body: ChartOverride):
+    match = _MBID_RE.search(body.release_group_mbid)
+    if not match:
+        raise HTTPException(status_code=422, detail="No valid MBID found in release_group_mbid")
+    rg_mbid = match.group(1).lower()
+
+    artist = body.artist.strip()
+    title = body.title.strip()
+    if not artist or not title:
+        raise HTTPException(status_code=422, detail="artist and title are required")
+
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                INSERT INTO chart_match_override (artist, title, release_group_mbid)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (lower(artist), lower(title))
+                DO UPDATE SET release_group_mbid = $3, updated_at = NOW()
+                """,
+                artist, title, rg_mbid,
+            )
+            # Reflect immediately in the current chart instead of waiting for
+            # the next weekly refresh.
+            await conn.execute(
+                """
+                UPDATE chart_album
+                SET release_group_mbid = $1, release_mbid = ''
+                WHERE lower(artist) = lower($2) AND lower(title) = lower($3)
+                """,
+                rg_mbid, artist, title,
+            )
+    return {"status": "ok", "release_group_mbid": rg_mbid}
+
+
+@router.delete("/override", dependencies=[Depends(get_current_admin_user_jwt)])
+async def delete_chart_override(body: ChartOverrideKey):
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM chart_match_override
+            WHERE lower(artist) = lower($1) AND lower(title) = lower($2)
+            """,
+            body.artist.strip(), body.title.strip(),
+        )
+    if result == "DELETE 0":
+        raise HTTPException(status_code=404, detail="No override for that entry")
+    return {"status": "deleted"}

--- a/app/charts.py
+++ b/app/charts.py
@@ -237,12 +237,44 @@ class ChartScraper:
 
 MB_API_URL = get_musicbrainz_root_url()
 
+
+async def load_match_overrides() -> dict:
+    """Manual release-group overrides keyed by (lower(artist), lower(title))."""
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT artist, title, release_group_mbid FROM chart_match_override"
+        )
+    return {
+        (r["artist"].casefold(), r["title"].casefold()): r["release_group_mbid"]
+        for r in rows
+    }
+
+
+def apply_match_overrides(entries: List[ChartEntry], overrides: dict) -> List[ChartEntry]:
+    """Set overridden MBIDs and return only the entries still needing MB lookup."""
+    remaining = []
+    for entry in entries:
+        rg_mbid = overrides.get((entry.artist.casefold(), entry.title.casefold()))
+        if rg_mbid:
+            entry.release_group_mbid = rg_mbid
+            entry.release_mbid = ""
+            entry.confidence = 100
+            logger.info(
+                f"Chart enrich: manual override for '{entry.title}' - '{entry.artist}' -> {rg_mbid}"
+            )
+        else:
+            remaining.append(entry)
+    return remaining
+
+
 async def enrich_entries(entries: List[ChartEntry]):
     # Limit enrichment to top 100 to save time/API limits
     # User-Agent matching scripts/chart.py exactly is crucial for the Official Charts API
     headers = {"User-Agent": "jamarr-chart/1.0 (+https://www.officialcharts.com/)"}
 
-    needs_enrichment = list(entries)
+    overrides = await load_match_overrides()
+    needs_enrichment = apply_match_overrides(list(entries), overrides)
 
     async with httpx.AsyncClient(timeout=20.0, follow_redirects=True, headers=headers) as client:
 

--- a/app/db.py
+++ b/app/db.py
@@ -456,6 +456,18 @@ async def init_db():
                 updated_at TIMESTAMPTZ DEFAULT NOW()
             );
             CREATE INDEX IF NOT EXISTS idx_chart_album_rg_mbid ON chart_album(release_group_mbid);
+
+            -- Manual MB release-group overrides for chart entries; keyed by
+            -- entry text so they survive the weekly chart_album wipe.
+            CREATE TABLE IF NOT EXISTS chart_match_override (
+                artist TEXT NOT NULL,
+                title TEXT NOT NULL,
+                release_group_mbid TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                updated_at TIMESTAMPTZ DEFAULT NOW()
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_match_override_key
+                ON chart_match_override (lower(artist), lower(title));
         """)
 
         # Create indexes

--- a/migrations/030_chart_match_override.sql
+++ b/migrations/030_chart_match_override.sql
@@ -1,0 +1,13 @@
+-- Manual MusicBrainz release-group overrides for chart entries.
+-- Keyed by chart entry text (case-insensitive) so overrides survive the
+-- weekly chart_album wipe/reinsert and re-apply when an album re-enters.
+CREATE TABLE IF NOT EXISTS chart_match_override (
+    artist TEXT NOT NULL,
+    title TEXT NOT NULL,
+    release_group_mbid TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_match_override_key
+    ON chart_match_override (lower(artist), lower(title));

--- a/tests/api/test_chart_override.py
+++ b/tests/api/test_chart_override.py
@@ -1,0 +1,159 @@
+"""Manual MusicBrainz release-group overrides for chart entries."""
+
+import pytest
+from httpx import AsyncClient
+
+from app.auth import hash_password
+from app.charts import ChartEntry, apply_match_overrides, load_match_overrides
+
+RG_MBID = "c172c2de-65c8-400b-a742-caaa2b9ffbe5"
+
+
+@pytest.fixture
+async def chart_row(db):
+    await db.execute("DELETE FROM chart_match_override")
+    await db.execute("DELETE FROM chart_album")
+    await db.execute(
+        """
+        INSERT INTO chart_album
+        (position, title, artist, last_week, peak, weeks, status, release_mbid, release_group_mbid)
+        VALUES (1, 'Mother Of Pearl', 'Freya Ridings', '2', '1', '5', 'up', '', 'wrong-mbid')
+        """
+    )
+    yield
+    await db.execute("DELETE FROM chart_match_override")
+    await db.execute("DELETE FROM chart_album")
+
+
+@pytest.mark.asyncio
+async def test_set_override_updates_current_chart(auth_client: AsyncClient, db, chart_row):
+    resp = await auth_client.put(
+        "/api/charts/override",
+        json={
+            "artist": "Freya Ridings",
+            "title": "Mother Of Pearl",
+            "release_group_mbid": RG_MBID,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["release_group_mbid"] == RG_MBID
+
+    row = await db.fetchrow("SELECT release_group_mbid, release_mbid FROM chart_album WHERE position = 1")
+    assert row["release_group_mbid"] == RG_MBID
+    assert row["release_mbid"] == ""
+
+    chart = (await auth_client.get("/api/charts")).json()
+    assert chart[0]["release_group_mbid"] == RG_MBID
+    assert chart[0]["overridden"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_override_accepts_musicbrainz_url(auth_client: AsyncClient, db, chart_row):
+    resp = await auth_client.put(
+        "/api/charts/override",
+        json={
+            "artist": "Freya Ridings",
+            "title": "Mother Of Pearl",
+            "release_group_mbid": f"https://musicbrainz.org/release-group/{RG_MBID}",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["release_group_mbid"] == RG_MBID
+
+
+@pytest.mark.asyncio
+async def test_set_override_rejects_garbage(auth_client: AsyncClient, chart_row):
+    resp = await auth_client.put(
+        "/api/charts/override",
+        json={"artist": "A", "title": "B", "release_group_mbid": "not-a-uuid"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces_existing_override(auth_client: AsyncClient, db, chart_row):
+    other = "11111111-2222-3333-4444-555555555555"
+    for mbid in (other, RG_MBID):
+        resp = await auth_client.put(
+            "/api/charts/override",
+            json={"artist": "Freya Ridings", "title": "Mother Of Pearl", "release_group_mbid": mbid},
+        )
+        assert resp.status_code == 200
+
+    rows = await db.fetch("SELECT release_group_mbid FROM chart_match_override")
+    assert [r["release_group_mbid"] for r in rows] == [RG_MBID]
+
+
+@pytest.mark.asyncio
+async def test_delete_override(auth_client: AsyncClient, db, chart_row):
+    await auth_client.put(
+        "/api/charts/override",
+        json={"artist": "Freya Ridings", "title": "Mother Of Pearl", "release_group_mbid": RG_MBID},
+    )
+    resp = await auth_client.request(
+        "DELETE",
+        "/api/charts/override",
+        json={"artist": "freya ridings", "title": "mother of pearl"},
+    )
+    assert resp.status_code == 200
+    assert await db.fetchval("SELECT count(*) FROM chart_match_override") == 0
+
+    resp = await auth_client.request(
+        "DELETE",
+        "/api/charts/override",
+        json={"artist": "Freya Ridings", "title": "Mother Of Pearl"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_override_requires_admin(client: AsyncClient, db, chart_row):
+    await db.execute('DELETE FROM "user" WHERE username = $1', "chart_nonadmin")
+    await db.fetchrow(
+        """
+        INSERT INTO "user" (username, email, password_hash, display_name, is_admin, created_at)
+        VALUES ($1, $2, $3, $4, FALSE, NOW())
+        RETURNING *
+        """,
+        "chart_nonadmin",
+        "chart_nonadmin@example.com",
+        hash_password("password123"),
+        "Chart Nonadmin",
+    )
+    login = await client.post(
+        "/api/auth/login", json={"username": "chart_nonadmin", "password": "password123"}
+    )
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+    resp = await client.put(
+        "/api/charts/override",
+        headers=headers,
+        json={"artist": "A", "title": "B", "release_group_mbid": RG_MBID},
+    )
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_applies_override_case_insensitively(db, chart_row):
+    await db.execute(
+        "INSERT INTO chart_match_override (artist, title, release_group_mbid) VALUES ($1, $2, $3)",
+        "Freya Ridings", "Mother Of Pearl", RG_MBID,
+    )
+    entries = [
+        ChartEntry(
+            position=1, title="MOTHER OF PEARL", artist="FREYA RIDINGS",
+            last_week="2", peak="1", weeks="5", status="up",
+        ),
+        ChartEntry(
+            position=2, title="Other Album", artist="Other Artist",
+            last_week="", peak="", weeks="1", status="new entry",
+        ),
+    ]
+
+    overrides = await load_match_overrides()
+    remaining = apply_match_overrides(entries, overrides)
+
+    assert entries[0].release_group_mbid == RG_MBID
+    assert entries[0].confidence == 100
+    # Only the non-overridden entry still needs a MusicBrainz lookup.
+    assert remaining == [entries[1]]

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -804,6 +804,7 @@ export interface ChartAlbum {
     artist_mbid?: string;
     art_sha1?: string;
     musicbrainz_url?: string;
+    overridden: boolean;
 }
 
 export async function fetchChart(fetchFn: any = fetchWithAuth): Promise<ChartAlbum[]> {
@@ -815,6 +816,27 @@ export async function fetchChart(fetchFn: any = fetchWithAuth): Promise<ChartAlb
 export async function refreshChart(): Promise<void> {
     const res = await fetchWithAuth('/api/charts/refresh', { method: 'POST' });
     if (!res.ok) throw new Error('Failed to refresh chart');
+}
+
+export async function setChartOverride(artist: string, title: string, releaseGroupMbid: string): Promise<void> {
+    const res = await fetchWithAuth('/api/charts/override', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ artist, title, release_group_mbid: releaseGroupMbid })
+    });
+    if (!res.ok) {
+        const detail = (await res.json().catch(() => null))?.detail;
+        throw new Error(detail || 'Failed to set chart override');
+    }
+}
+
+export async function deleteChartOverride(artist: string, title: string): Promise<void> {
+    const res = await fetchWithAuth('/api/charts/override', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ artist, title })
+    });
+    if (!res.ok) throw new Error('Failed to remove chart override');
 }
 
 // Scheduler

--- a/web/src/lib/components/ChartOverrideModal.svelte
+++ b/web/src/lib/components/ChartOverrideModal.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+    import { fade, scale } from "svelte/transition";
+    import { createEventDispatcher } from "svelte";
+    import {
+        setChartOverride,
+        deleteChartOverride,
+        type ChartAlbum,
+    } from "$lib/api";
+
+    export let entry: ChartAlbum | null = null;
+    export let visible = false;
+
+    const dispatch = createEventDispatcher();
+
+    let mbidInput = "";
+    let saving = false;
+    let error = "";
+
+    $: if (visible && entry) {
+        mbidInput = entry.overridden ? entry.release_group_mbid || "" : "";
+        error = "";
+    }
+
+    function close() {
+        visible = false;
+        dispatch("close");
+    }
+
+    async function save() {
+        if (!entry || !mbidInput.trim()) return;
+        saving = true;
+        error = "";
+        try {
+            await setChartOverride(entry.artist, entry.title, mbidInput.trim());
+            dispatch("saved");
+            close();
+        } catch (e) {
+            error = e instanceof Error ? e.message : "Failed to save override";
+        } finally {
+            saving = false;
+        }
+    }
+
+    async function removeOverride() {
+        if (!entry) return;
+        saving = true;
+        error = "";
+        try {
+            await deleteChartOverride(entry.artist, entry.title);
+            dispatch("saved");
+            close();
+        } catch (e) {
+            error =
+                e instanceof Error ? e.message : "Failed to remove override";
+        } finally {
+            saving = false;
+        }
+    }
+</script>
+
+{#if visible && entry}
+    <div
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-xs p-4 cursor-pointer"
+        transition:fade
+        on:click|self={close}
+        role="button"
+        tabindex="0"
+        on:keydown={(e) => e.key === "Escape" && close()}
+    >
+        <div
+            class="bg-surface-50 border border-white/10 rounded-2xl w-full max-w-md shadow-2xl overflow-hidden flex flex-col"
+            transition:scale
+        >
+            <div
+                class="p-4 border-b border-white/10 flex justify-between items-center"
+            >
+                <h2 class="text-lg font-bold">Fix MusicBrainz Match</h2>
+                <button
+                    class="btn btn-ghost btn-sm btn-circle"
+                    aria-label="Close"
+                    on:click={close}
+                >
+                    <svg
+                        class="w-5 h-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
+
+            <div class="p-4 flex flex-col gap-3">
+                <div class="text-sm text-white/70">
+                    <span class="font-medium text-white">{entry.title}</span>
+                    — {entry.artist}
+                </div>
+                {#if entry.release_group_mbid}
+                    <div class="text-xs text-white/50 break-all">
+                        Current match: {entry.release_group_mbid}
+                        {#if entry.overridden}(manual){/if}
+                    </div>
+                {:else}
+                    <div class="text-xs text-white/50">Currently unmatched</div>
+                {/if}
+                <input
+                    type="text"
+                    class="input input-sm w-full bg-white/5 border-white/10 focus:border-primary-500"
+                    placeholder="Release group MBID or MusicBrainz URL"
+                    bind:value={mbidInput}
+                    on:keydown={(e) => e.key === "Enter" && save()}
+                />
+                {#if error}
+                    <div class="text-xs text-error-500">{error}</div>
+                {/if}
+            </div>
+
+            <div
+                class="p-4 border-t border-white/10 bg-white/5 flex justify-between items-center"
+            >
+                {#if entry.overridden}
+                    <button
+                        class="btn btn-sm btn-ghost text-error-500"
+                        disabled={saving}
+                        on:click={removeOverride}
+                    >
+                        Remove Override
+                    </button>
+                {:else}
+                    <span></span>
+                {/if}
+                <button
+                    class="btn btn-sm variant-filled-primary"
+                    disabled={saving || !mbidInput.trim()}
+                    on:click={save}
+                >
+                    {#if saving}
+                        <span class="loading loading-spinner loading-xs"></span>
+                    {/if}
+                    Save
+                </button>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/web/src/routes/charts/+page.svelte
+++ b/web/src/routes/charts/+page.svelte
@@ -4,12 +4,21 @@
   import { refreshChart, triggerPearlarrDownload, fetchTracks } from "$api";
   import { goto, invalidateAll } from "$app/navigation";
   import { setQueue, addToQueue } from "$stores/player";
+  import { currentUser } from "$stores/user";
   import IconButton from "$lib/components/IconButton.svelte";
+  import ChartOverrideModal from "$lib/components/ChartOverrideModal.svelte";
 
   export let data: { chart: ChartAlbum[] };
 
   let refreshing = false;
   let downloadingMbids = new Set<string>();
+  let overrideEntry: ChartAlbum | null = null;
+  let overrideModalVisible = false;
+
+  function openOverrideModal(entry: ChartAlbum) {
+    overrideEntry = entry;
+    overrideModalVisible = true;
+  }
 
   async function handleRefresh() {
     refreshing = true;
@@ -355,6 +364,35 @@
               <span class="w-0.5 h-0.5 bg-current rounded-full"></span>
             {/if}
             <span>{entry.weeks} Wks</span>
+            {#if entry.overridden}
+              <span
+                class="badge variant-soft-primary text-[9px]"
+                title="MusicBrainz match set manually">Manual</span
+              >
+            {/if}
+            {#if $currentUser?.is_admin}
+              <button
+                type="button"
+                class="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-muted hover:text-default"
+                title="Fix MusicBrainz match"
+                aria-label="Fix MusicBrainz match for {title}"
+                on:click={() => openOverrideModal(entry)}
+              >
+                <svg
+                  class="w-3.5 h-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+              </button>
+            {/if}
           </div>
         </div>
       </div>
@@ -383,3 +421,9 @@
     {/if}
   </div>
 </section>
+
+<ChartOverrideModal
+  bind:visible={overrideModalVisible}
+  entry={overrideEntry}
+  on:saved={() => invalidateAll()}
+/>


### PR DESCRIPTION
Chart entries sometimes mismatch or don't match a MusicBrainz release group (fuzzy match misses, or the MB server is down during refresh — e.g. *Mother Of Pearl* by Freya Ridings right now). This adds an admin override: click the pencil on a chart entry, paste the release-group MBID or any MusicBrainz URL, done.

## How it works

- **`chart_match_override` table** (migration `030` + `app/db.py` init) keyed by `lower(artist), lower(title)` — chart text, not position, because `refresh_chart_task` wipes and reinserts `chart_album` weekly. Overrides survive refreshes and re-apply if an album re-enters the chart.
- **`PUT /charts/override`** (admin): upserts the override **and** updates the current `chart_album` row immediately — no waiting for the next refresh. Accepts a bare MBID or a full `musicbrainz.org/release-group/...` URL (UUID extracted server-side). 422 if no UUID found.
- **`DELETE /charts/override`** (admin): removes it; entry re-matches naturally on next refresh.
- **`enrich_entries`** applies overrides before any MusicBrainz lookup (confidence 100, lookups skipped) — works even while the MB server is unreachable.
- **`GET /charts`** gains `overridden: bool`.

## UI

Pencil button per chart card (admin only, shown on hover) opens a modal: shows current match state, input for MBID/URL, and a *Remove Override* action for manual matches. Overridden entries get a small **Manual** badge. `in_library` detection keys on `release_group_mbid`, so a corrected match lights up library state immediately.

## Also

- AGENTS.md: corrected the stale DB-change convention — schema lives in both `migrations/` and `app/db.py` `init_db`, and schema docs are generated (`docs/DATABASE_SCHEMA.md` no longer exists).

## Tests

- `tests/api/test_chart_override.py` — upsert + immediate chart update, URL parsing, garbage rejection, delete (case-insensitive), admin-only enforcement, and enrichment applying overrides case-insensitively while skipping MB lookup.
- Full suite: 390 backend + 11 TUI passed; frontend check/lint/unit/build all pass.