### PR TITLE
Security and reliability hardening: auth, streaming, UPnP noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,8 +104,9 @@ STREAM_TOKEN_TTL_SECONDS=300
 STREAM_TOKEN_AUDIENCE=jamarr-stream
 
 # --- Session cookies ---
-# Set to true in production (requires HTTPS)
-REFRESH_COOKIE_SECURE=false
+# Defaults to true when ENV=production, false otherwise. Only uncomment to
+# override — false in production sends the session cookie over plain HTTP.
+#REFRESH_COOKIE_SECURE=false
 REFRESH_COOKIE_NAME=jamarr_refresh
 
 # --- Public / reverse-proxy hardening ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,10 @@ Backend tests need the test DB stack (`docker-compose.test.yml`); `test.sh` brin
 ## Gotchas
 
 - Python 3.14 required.
+- Auth is Bearer-header only; no `access_token=` query fallback. SSE endpoints
+  (`/api/library/events`, `/api/lastfm/events`) auth via the refresh cookie.
+- `DB_PASS` has no compose default — must be set in `.env`. Production startup
+  fails fast if `JWT_SECRET_KEY` is unset or a placeholder.
 - UPnP needs host networking — discovery won't work in bridged containers.
 - `HOST_IP` auto-derived in `dev.sh`/`deploy.sh` via route lookup; override by exporting it.
 - Frontend dev caches (`web/.svelte-kit`, `web/.vite`) are cleared on `dev.sh` start.

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -14,7 +14,7 @@ from app.auth import (
     verify_password,
     get_user_by_username_or_email,
     create_refresh_session,
-    get_refresh_session,
+    get_refresh_session_state,
     revoke_refresh_session,
     revoke_all_user_sessions,
 )
@@ -22,6 +22,7 @@ from app.auth_tokens import (
     create_access_token,
     generate_refresh_token,
     hash_refresh_token,
+    REFRESH_COOKIE_NAME,
     REFRESH_TOKEN_TTL_DAYS,
 )
 from app.api.deps import get_current_admin_user_jwt, get_current_user_jwt
@@ -36,11 +37,14 @@ limiter = Limiter(
 )
 
 # Configuration
-REFRESH_COOKIE_NAME = os.getenv("REFRESH_COOKIE_NAME", "jamarr_refresh")
 if "REFRESH_COOKIE_SECURE" in os.environ:
     REFRESH_COOKIE_SECURE = os.getenv("REFRESH_COOKIE_SECURE", "false").lower() == "true"
 else:
     REFRESH_COOKIE_SECURE = ENV == "production"
+
+# Replays of a rotated refresh token within this window are treated as a benign
+# concurrent-refresh race; older replays trigger revocation of all sessions.
+REFRESH_REUSE_GRACE = timedelta(seconds=30)
 
 
 class CreateUserBody(BaseModel):
@@ -194,6 +198,18 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials."
         )
 
+    if not user.get("is_active", True):
+        log_security_event(
+            "login_inactive_user",
+            request,
+            level=logging.WARNING,
+            user_id=user["id"],
+            username=user["username"],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Account is disabled."
+        )
+
     # Update last login timestamp
     await db.execute(
         'UPDATE "user" SET last_login_at = $1 WHERE id = $2',
@@ -269,20 +285,61 @@ async def refresh(
             detail="Missing refresh token",
         )
     
-    # Lookup refresh session
+    # Lookup refresh session (including revoked/expired, for reuse detection)
     token_hash = hash_refresh_token(refresh_token)
-    session = await get_refresh_session(db, token_hash)
-    
+    session = await get_refresh_session_state(db, token_hash)
+
     if not session:
-        # Token is either revoked, expired, or doesn't exist
         log_security_event("refresh_invalid", request, level=logging.WARNING)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
-    
+
     user_id = session["user_id"]
-    
+    now = datetime.now(timezone.utc)
+
+    if session["revoked_at"] is not None:
+        # A rotated token was replayed. Within a short grace window this is a
+        # benign race (two tabs refreshing concurrently); beyond it, assume the
+        # token was stolen and revoke every session for the user.
+        if now - session["revoked_at"] > REFRESH_REUSE_GRACE:
+            await revoke_all_user_sessions(db, user_id)
+            log_security_event(
+                "refresh_reuse_detected",
+                request,
+                level=logging.WARNING,
+                user_id=user_id,
+                username=session["username"],
+            )
+        else:
+            log_security_event(
+                "refresh_race", request, level=logging.INFO, user_id=user_id
+            )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
+    if session["expires_at"] <= now:
+        log_security_event("refresh_expired", request, level=logging.INFO)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
+    if not session.get("is_active", True):
+        log_security_event(
+            "refresh_inactive_user",
+            request,
+            level=logging.WARNING,
+            user_id=user_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
     # Rotate refresh token (revoke old, create new)
     await revoke_refresh_session(db, token_hash)
     

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -5,8 +5,12 @@ from typing import Optional
 import asyncpg
 from fastapi import Depends, Header, HTTPException, Request, status
 
-from app.auth import get_user_by_id
-from app.auth_tokens import verify_access_token
+from app.auth import get_refresh_session, get_user_by_id
+from app.auth_tokens import (
+    REFRESH_COOKIE_NAME,
+    hash_refresh_token,
+    verify_access_token,
+)
 from app.db import get_db
 from app.security import log_security_event
 
@@ -17,25 +21,20 @@ async def get_current_user_jwt(
     db: asyncpg.Connection = Depends(get_db),
 ) -> asyncpg.Record:
     """Dependency to require JWT authentication.
-    
+
     Extracts and validates JWT from Authorization header.
     Returns user record from database.
-    
+
     Args:
         authorization: Authorization header value (should be "Bearer <token>")
         db: Database connection
-        
+
     Returns:
         User record from database
-        
+
     Raises:
         HTTPException: 401 if token is missing, invalid, or expired
     """
-    if not authorization and request is not None:
-        token = request.query_params.get("access_token")
-        if token:
-            authorization = f"Bearer {token}"
-
     if not authorization:
         log_security_event("auth_missing", request, level=logging.INFO)
         raise HTTPException(
@@ -146,15 +145,73 @@ async def get_optional_user_jwt(
     Returns:
         User record if valid token provided, None otherwise
     """
-    if not authorization and request is not None:
-        token = request.query_params.get("access_token")
-        if token:
-            authorization = f"Bearer {token}"
-
     if not authorization:
         return None
-    
+
     try:
         return await get_current_user_jwt(authorization, request, db)
     except HTTPException:
         return None
+
+
+async def get_user_from_refresh_cookie(
+    request: Request, db: asyncpg.Connection
+) -> asyncpg.Record:
+    """Authenticate via the refresh-token cookie.
+
+    For requests that cannot carry an Authorization header: EventSource (SSE)
+    connections and external OAuth callback redirects. The cookie is httponly
+    and scoped to /api, so it never appears in URLs or proxy logs.
+    """
+    refresh_token = request.cookies.get(REFRESH_COOKIE_NAME)
+    if not refresh_token:
+        log_security_event("auth_missing", request, level=logging.INFO)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    session = await get_refresh_session(db, hash_refresh_token(refresh_token))
+    if not session:
+        log_security_event("auth_invalid_token", request, level=logging.WARNING)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    user = await get_user_by_id(db, session["user_id"])
+    if not user or not user.get("is_active", True):
+        log_security_event(
+            "auth_inactive_user",
+            request,
+            level=logging.WARNING,
+            user_id=session["user_id"],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    return user
+
+
+async def get_current_user_jwt_or_cookie(
+    request: Request,
+    authorization: Optional[str] = Header(None),
+    db: asyncpg.Connection = Depends(get_db),
+) -> asyncpg.Record:
+    """Require auth via Bearer header, falling back to the refresh cookie.
+
+    Only for endpoints that browsers must reach without custom headers (SSE).
+    """
+    if authorization:
+        return await get_current_user_jwt(authorization, request, db)
+    return await get_user_from_refresh_cookie(request, db)
+
+
+async def get_current_admin_user_jwt_or_cookie(
+    request: Request,
+    user: asyncpg.Record = Depends(get_current_user_jwt_or_cookie),
+) -> asyncpg.Record:
+    """Require admin auth via Bearer header or refresh cookie (SSE endpoints)."""
+    return require_admin_user(user, request)

--- a/app/api/lastfm.py
+++ b/app/api/lastfm.py
@@ -5,7 +5,6 @@ Last.fm API endpoints for authentication and account management.
 import asyncio
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
@@ -15,9 +14,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 
-from app.auth import get_user_by_id, get_refresh_session
-from app.api.deps import get_current_user_jwt
-from app.auth_tokens import hash_refresh_token
+from app.api.deps import (
+    get_current_user_jwt,
+    get_current_user_jwt_or_cookie,
+    get_user_from_refresh_cookie,
+)
 from app.db import get_db
 from app import lastfm
 from app.lastfm_sync_manager import LastfmSyncManager
@@ -25,7 +26,6 @@ from app.lastfm_sync_manager import LastfmSyncManager
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-REFRESH_COOKIE_NAME = os.getenv("REFRESH_COOKIE_NAME", "jamarr_refresh")
 
 
 class ToggleRequest(BaseModel):
@@ -72,7 +72,7 @@ async def lastfm_callback(
     logger.info("Last.fm callback received")
     
     try:
-        user = await _get_user_from_refresh_cookie(request, db)
+        user = await get_user_from_refresh_cookie(request, db)
         logger.info(f"User authenticated: {user['username']}")
     except Exception as e:
         logger.error(f"Authentication failed in callback: {e}")
@@ -662,7 +662,7 @@ async def sync_scrobbles_for_user(
 
 @router.get("/api/lastfm/events")
 async def lastfm_events(
-    user: asyncpg.Record = Depends(get_current_user_jwt),
+    user: asyncpg.Record = Depends(get_current_user_jwt_or_cookie),
 ):
     manager = LastfmSyncManager.get_instance()
 
@@ -672,21 +672,3 @@ async def lastfm_events(
             yield f"data: {json.dumps(event)}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
-async def _get_user_from_refresh_cookie(
-    request: Request,
-    db: asyncpg.Connection,
-) -> asyncpg.Record:
-    refresh_token = request.cookies.get(REFRESH_COOKIE_NAME)
-    if not refresh_token:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
-
-    token_hash = hash_refresh_token(refresh_token)
-    session = await get_refresh_session(db, token_hash)
-    if not session:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
-
-    user = await get_user_by_id(db, session["user_id"])
-    if not user or not user.get("is_active", True):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
-
-    return user

--- a/app/api/scan.py
+++ b/app/api/scan.py
@@ -5,9 +5,18 @@ from typing import Optional
 import json
 
 from app.scanner.scan_manager import ScanManager
-from app.api.deps import get_current_admin_user_jwt
+from app.api.deps import (
+    get_current_admin_user_jwt,
+    get_current_admin_user_jwt_or_cookie,
+)
 
 router = APIRouter(dependencies=[Depends(get_current_admin_user_jwt)])
+
+# EventSource cannot send an Authorization header, so the SSE endpoint lives on
+# its own router and authenticates via the refresh cookie as a fallback.
+events_router = APIRouter(
+    dependencies=[Depends(get_current_admin_user_jwt_or_cookie)]
+)
 
 
 class ScanRequest(BaseModel):
@@ -163,7 +172,7 @@ async def get_scan_status():
     }
 
 
-@router.get("/api/library/events")
+@events_router.get("/api/library/events")
 async def sse_events():
     manager = ScanManager.get_instance()
 

--- a/app/api/stream.py
+++ b/app/api/stream.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse
-from app.db import get_db
+from app.db import get_db, get_pool
 from app.api.deps import get_current_user_jwt, get_optional_user_jwt
 from app.auth_tokens import create_stream_token, verify_stream_token
 from app.services.renderer.token_policy import stream_token_ttl_seconds
@@ -56,26 +56,34 @@ async def get_stream_url(
 
 @router.api_route("/api/stream/{track_id}", methods=["GET", "HEAD"])
 async def stream_track(
+    request: Request,
     track_id: int,
     token: Optional[str] = None,
     quality: Optional[str] = None,
-    user: Optional[asyncpg.Record] = Depends(get_optional_user_jwt),
-    db: asyncpg.Connection = Depends(get_db),
 ):
+    # Deliberately no Depends(get_db): dependencies with yield are only torn
+    # down after the response finishes, which would pin a pool connection for
+    # the whole file transfer. Acquire briefly instead.
+    pool = get_pool()
     if token:
         stream_claims = verify_stream_token(token, track_id)
-    elif not user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
     else:
+        async with pool.acquire() as db:
+            user = await get_optional_user_jwt(
+                request.headers.get("authorization"), request, db
+            )
+        if not user:
+            raise HTTPException(status_code=401, detail="Not authenticated")
         stream_claims = {}
-    row = await db.fetchrow(
-        """
-        SELECT id, path, codec, sample_rate_hz, bit_depth, bitrate, quick_hash
-        FROM track
-        WHERE id = $1
-        """,
-        track_id,
-    )
+    async with pool.acquire() as db:
+        row = await db.fetchrow(
+            """
+            SELECT id, path, codec, sample_rate_hz, bit_depth, bitrate, quick_hash
+            FROM track
+            WHERE id = $1
+            """,
+            track_id,
+        )
     if not row:
         raise HTTPException(status_code=404, detail="Track not found")
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -119,6 +119,30 @@ async def get_refresh_session(
     return row
 
 
+async def get_refresh_session_state(
+    db: asyncpg.Connection, token_hash: str
+) -> Optional[asyncpg.Record]:
+    """Get refresh session by token hash regardless of revocation or expiry.
+
+    Unlike get_refresh_session, this returns revoked/expired sessions so the
+    caller can distinguish "unknown token" from "rotated token replayed",
+    which is the signal for refresh-token theft detection.
+    """
+    return await db.fetchrow(
+        """
+        SELECT
+            s.*,
+            u.username,
+            u.is_active
+        FROM auth_refresh_session s
+        JOIN "user" u ON u.id = s.user_id
+        WHERE s.token_hash = $1
+        LIMIT 1
+        """,
+        token_hash,
+    )
+
+
 async def revoke_refresh_session(db: asyncpg.Connection, token_hash: str) -> None:
     """Revoke a refresh session by setting revoked_at timestamp.
     

--- a/app/auth_tokens.py
+++ b/app/auth_tokens.py
@@ -22,6 +22,36 @@ ACCESS_TOKEN_TTL_MINUTES = int(os.getenv("ACCESS_TOKEN_TTL_MINUTES", "10"))
 REFRESH_TOKEN_TTL_DAYS = int(os.getenv("REFRESH_TOKEN_TTL_DAYS", "21"))
 STREAM_TOKEN_TTL_SECONDS = int(os.getenv("STREAM_TOKEN_TTL_SECONDS", "300"))
 STREAM_TOKEN_AUDIENCE = os.getenv("STREAM_TOKEN_AUDIENCE", "jamarr-stream")
+REFRESH_COOKIE_NAME = os.getenv("REFRESH_COOKIE_NAME", "jamarr_refresh")
+
+# Known non-secrets that must never be accepted as JWT_SECRET_KEY in production.
+_PLACEHOLDER_SECRETS = {
+    "change-this-to-a-random-secret-key",  # .env.example placeholder
+    "dev-secret",  # development fallback
+}
+
+
+def validate_jwt_secret_at_startup() -> None:
+    """Fail fast in production when JWT_SECRET_KEY is missing or a placeholder.
+
+    Without this the app boots fine and only returns 500s once the first
+    token is created or verified.
+    """
+    if os.getenv("ENV", "development").lower() != "production":
+        return
+    secret = os.getenv("JWT_SECRET_KEY", "")
+    if not secret or secret in _PLACEHOLDER_SECRETS:
+        raise RuntimeError(
+            "JWT_SECRET_KEY must be set to a strong random value in production. "
+            "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+        )
+    if len(secret) < 32:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "JWT_SECRET_KEY is shorter than 32 characters; consider regenerating "
+            "with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+        )
 
 
 def _get_jwt_settings() -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,14 @@ import os
 import re
 
 from fastapi import FastAPI, HTTPException
+from app.auth_tokens import validate_jwt_secret_at_startup
 from app.db import init_db, close_db
 from app.security import configure_security_middleware, fastapi_docs_config, is_production
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    validate_jwt_secret_at_startup()
     await init_db()
     from app.services.renderer import get_renderer_registry
     from app.scanner.scan_manager import ScanManager
@@ -78,6 +80,7 @@ app.include_router(stream.router)
 app.include_router(player.router)
 app.include_router(search.router)
 app.include_router(scan.router)
+app.include_router(scan.events_router)
 app.include_router(auth.router)
 app.include_router(media_quality.router)
 app.include_router(playlist.router)

--- a/app/media/art.py
+++ b/app/media/art.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import FileResponse
-from app.db import get_db
+from starlette.concurrency import run_in_threadpool
+from app.db import get_pool
 from app.security import is_production
 import os
 import io
@@ -99,122 +100,121 @@ def _is_not_modified(request: Request, etag: str, stat_result: os.stat_result) -
     return False
 
 
+def _create_resized(original_path: str, resized_path: str, target_size: int) -> None:
+    """Resize *original_path* to fit target_size and save as JPEG. Blocking."""
+    from PIL import Image
+
+    os.makedirs(os.path.dirname(resized_path), exist_ok=True)
+    with Image.open(original_path) as img:
+        # Convert to RGB if needed (handles PNG with transparency)
+        if img.mode in ("RGBA", "LA", "P"):
+            background = Image.new("RGB", img.size, (255, 255, 255))
+            if img.mode == "P":
+                img = img.convert("RGBA")
+            background.paste(
+                img,
+                mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None,
+            )
+            img = background
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+
+        width, height = img.size
+        if width > target_size or height > target_size:
+            if width > height:
+                new_width = target_size
+                new_height = int(height * (target_size / width))
+            else:
+                new_height = target_size
+                new_width = int(width * (target_size / height))
+
+            img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+
+        img.save(resized_path, format="JPEG", quality=85, optimize=True)
+
+
+def _sniff_mime(path: str) -> str | None:
+    """Guess image mime from file magic bytes. Blocking."""
+    try:
+        with open(path, "rb") as f:
+            header = f.read(12)
+            if header.startswith(b"\xff\xd8\xff"):
+                return "image/jpeg"
+            elif header.startswith(b"\x89PNG\r\n\x1a\n"):
+                return "image/png"
+            elif header.startswith(b"GIF8"):
+                return "image/gif"
+            elif header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+                return "image/webp"
+    except Exception:
+        pass
+    return None
+
+
+def _cached_file_response(
+    request: Request, path: str, sha1: str, media_type: str | None
+) -> Response:
+    stat_result = os.stat(path)
+    etag = f'W/"{sha1}-{int(stat_result.st_mtime)}-{stat_result.st_size}"'
+    if _is_not_modified(request, etag, stat_result):
+        return Response(status_code=304, headers=_build_cache_headers(stat_result, etag))
+    response = FileResponse(path, media_type=media_type)
+    response.headers.update(_build_cache_headers(stat_result, etag))
+    return response
+
+
 @router.api_route("/art/file/{sha1}", methods=["GET", "HEAD"])
 async def get_artwork_by_sha1(sha1: str, request: Request, max_size: int = 0):
     if len(sha1) != 40 or any(c not in '0123456789abcdefABCDEF' for c in sha1):
         raise HTTPException(status_code=400, detail="Invalid SHA1 format")
 
-    async for db in get_db():
+    # Acquire briefly: the connection must not stay checked out while we do
+    # file IO, image resizing, or send the response.
+    async with get_pool().acquire() as db:
         row = await db.fetchrow(
             "SELECT path_on_disk, mime FROM artwork WHERE sha1 = $1", sha1
         )
-        if not row:
-            raise HTTPException(status_code=404, detail="Artwork not found")
+    if not row:
+        raise HTTPException(status_code=404, detail="Artwork not found")
 
-        original_path = _get_art_path(sha1, row["path_on_disk"])
-        mime = row["mime"]
+    original_path = _get_art_path(sha1, row["path_on_disk"])
+    mime = row["mime"]
 
-        if not os.path.isfile(original_path):
-            raise HTTPException(status_code=404, detail="Artwork file missing")
+    if not os.path.isfile(original_path):
+        raise HTTPException(status_code=404, detail="Artwork file missing")
 
-        # If resizing requested
-        if max_size > 0:
-            target_size = _snap_size(max_size)
-            subdir = sha1[:2]
-            resized_dir = _safe_join(CACHE_DIR, "resized", str(target_size), subdir)
-            resized_path = os.path.join(resized_dir, sha1)
+    # If resizing requested
+    if max_size > 0:
+        target_size = _snap_size(max_size)
+        subdir = sha1[:2]
+        resized_dir = _safe_join(CACHE_DIR, "resized", str(target_size), subdir)
+        resized_path = os.path.join(resized_dir, sha1)
 
-            # Serve from cache if exists
-            if os.path.isfile(resized_path):  # lgtm[py/path-injection]
-                stat_result = os.stat(resized_path)
-                etag = f'W/"{sha1}-{int(stat_result.st_mtime)}-{stat_result.st_size}"'
-                if _is_not_modified(request, etag, stat_result):
-                    return Response(status_code=304, headers=_build_cache_headers(stat_result, etag))
-                response = FileResponse(resized_path, media_type="image/jpeg")
-                response.headers.update(_build_cache_headers(stat_result, etag))
-                return response
+        # Serve from cache if exists
+        if os.path.isfile(resized_path):  # lgtm[py/path-injection]
+            return _cached_file_response(request, resized_path, sha1, "image/jpeg")
 
-            # Create if missing
-            from PIL import Image
+        # Create if missing; Pillow decode/resize is CPU-bound, keep it off
+        # the event loop.
+        try:
+            await run_in_threadpool(
+                _create_resized, original_path, resized_path, target_size
+            )
+            return _cached_file_response(request, resized_path, sha1, "image/jpeg")
+        except Exception:
+            # Fallback to original file on error
+            pass
 
-            try:
-                os.makedirs(resized_dir, exist_ok=True)
-                with Image.open(original_path) as img:
-                    # Convert to RGB if needed (handles PNG with transparency)
-                    if img.mode in ("RGBA", "LA", "P"):
-                        background = Image.new("RGB", img.size, (255, 255, 255))
-                        if img.mode == "P":
-                            img = img.convert("RGBA")
-                        background.paste(
-                            img,
-                            mask=img.split()[-1]
-                            if img.mode in ("RGBA", "LA")
-                            else None,
-                        )
-                        img = background
-                    elif img.mode != "RGB":
-                        img = img.convert("RGB")
+    # Fallback
+    if not mime:
+        mime = await run_in_threadpool(_sniff_mime, original_path)
 
-                    width, height = img.size
-                    should_resize = width > target_size or height > target_size
-
-                    if should_resize:
-                        if width > height:
-                            new_width = target_size
-                            new_height = int(height * (target_size / width))
-                        else:
-                            new_height = target_size
-                            new_width = int(width * (target_size / height))
-
-                        img = img.resize(
-                            (new_width, new_height), Image.Resampling.LANCZOS
-                        )
-
-                    # Save to cache
-                    img.save(resized_path, format="JPEG", quality=85, optimize=True)
-
-                    stat_result = os.stat(resized_path)
-                    etag = f'W/"{sha1}-{int(stat_result.st_mtime)}-{stat_result.st_size}"'
-                    if _is_not_modified(request, etag, stat_result):
-                        return Response(status_code=304, headers=_build_cache_headers(stat_result, etag))
-                    response = FileResponse(resized_path, media_type="image/jpeg")
-                    response.headers.update(_build_cache_headers(stat_result, etag))
-                    return response
-            except Exception:
-                # Fallback to original file on error
-                pass
-
-        # Fallback
-        if not mime:
-            # Try to sniff mime from file header
-            try:
-                with open(original_path, "rb") as f:
-                    header = f.read(12)
-                    if header.startswith(b"\xff\xd8\xff"):
-                        mime = "image/jpeg"
-                    elif header.startswith(b"\x89PNG\r\n\x1a\n"):
-                        mime = "image/png"
-                    elif header.startswith(b"GIF8"):
-                        mime = "image/gif"
-                    elif header.startswith(b"RIFF") and header[8:12] == b"WEBP":
-                        mime = "image/webp"
-            except Exception:
-                pass
-
-        stat_result = os.stat(original_path)
-        etag = f'W/"{sha1}-{int(stat_result.st_mtime)}-{stat_result.st_size}"'
-        if _is_not_modified(request, etag, stat_result):
-            return Response(status_code=304, headers=_build_cache_headers(stat_result, etag))
-        response = FileResponse(original_path, media_type=mime)
-        response.headers.update(_build_cache_headers(stat_result, etag))
-        return response
-
-    raise HTTPException(status_code=500, detail="Database error")
+    return _cached_file_response(request, original_path, sha1, mime)
 
 
 @router.get("/art/renderer/{udn}")
 async def get_renderer_icon(udn: str, request: Request, max_size: int = 0):
-    async for db in get_db():
+    async with get_pool().acquire() as db:
         row = await db.fetchrow(
             """
             SELECT a.sha1
@@ -226,7 +226,7 @@ async def get_renderer_icon(udn: str, request: Request, max_size: int = 0):
             """,
             udn,
         )
-        if not row:
-            raise HTTPException(status_code=404, detail="Renderer icon not found")
+    if not row:
+        raise HTTPException(status_code=404, detail="Renderer icon not found")
 
-        return await get_artwork_by_sha1(row["sha1"], max_size=max_size, request=request)
+    return await get_artwork_by_sha1(row["sha1"], max_size=max_size, request=request)

--- a/app/monitoring.py
+++ b/app/monitoring.py
@@ -5,6 +5,7 @@ import time
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
 from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
 
 from app.api.deps import get_current_admin_user_jwt
 from app.security import (
@@ -61,6 +62,7 @@ def _resolve_log_file(key: str) -> Path:
 
 
 def tail_log_lines(path: Path, line_count: int) -> list[str]:
+    """Read the last *line_count* lines of a log. Blocking — reads whole file."""
     if not path.exists():
         return []
     with path.open("r", encoding="utf-8", errors="replace") as handle:
@@ -92,7 +94,9 @@ async def monitoring_summary():
                 modified_at=stat.st_mtime if stat else None,
             )
         )
-    return MonitoringSummary(logs=logs, alerts=recent_security_alerts())
+    return MonitoringSummary(
+        logs=logs, alerts=await run_in_threadpool(recent_security_alerts)
+    )
 
 
 @router.get("/logs", response_model=LogResponse)
@@ -104,7 +108,7 @@ async def monitoring_logs(
     return LogResponse(
         key=file,
         name=LOG_FILES[file],
-        lines=tail_log_lines(path, lines),
+        lines=await run_in_threadpool(tail_log_lines, path, lines),
     )
 
 

--- a/app/services/upnp/discovery.py
+++ b/app/services/upnp/discovery.py
@@ -271,10 +271,11 @@ class UPnPDiscovery:
         entry = self._failure_state.get(location) or {}
         failures = entry.get("failures", 0) + 1
 
-        # ERROR on the first failure only; repeats are expected (TVs in standby
-        # answer SSDP but refuse HTTP) and logged at DEBUG.
+        # WARNING on the first failure only; repeats are expected (TVs in standby
+        # answer SSDP but refuse HTTP) and logged at DEBUG. The failure state is
+        # in-memory, so each process restart logs one line per dead location.
         if failures == 1:
-            logger.error(f"Error adding renderer from {location}: {error}")
+            logger.warning(f"Error adding renderer from {location}: {error}")
             self.manager.log(f"Error adding renderer: {error}")
         else:
             logger.debug(f"Error adding renderer from {location} (failure {failures}): {error}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       DB_HOST: ${DB_HOST:-127.0.0.1}
       DB_PORT: ${DB_PORT:-8110}
       DB_USER: ${DB_USER:-jamarr}
-      DB_PASS: ${DB_PASS:-jamarr}
+      DB_PASS: ${DB_PASS:?DB_PASS must be set in .env}
       DB_NAME: ${DB_NAME:-jamarr}
       JAMARR_STREAM_CACHE_DIR: ${JAMARR_STREAM_CACHE_DIR:-/app/music-cache/cache}
 

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -117,7 +117,7 @@ Recommended endpoints:
 4. On API 401:
    - attempt `/api/auth/refresh` once, then retry the request.
    - if refresh fails, redirect to login.
-5. For endpoints that cannot send headers (EventSource, `<img>`), append `access_token=<jwt>` as a query param.
+5. Endpoints that cannot send headers (EventSource/SSE) authenticate via the httponly refresh cookie instead; access tokens are never placed in URLs (they would leak into reverse-proxy logs and browser history).
 
 ### 4.3 Script / curl flow
 

--- a/docs/architecture/decisions/0001-jwt-auth.md
+++ b/docs/architecture/decisions/0001-jwt-auth.md
@@ -35,6 +35,8 @@ signed URL is used instead of cookie auth (see streaming flow / ADR-0003).
 - Stolen access tokens expire fast; refresh reuse hard-fails (401) and can be
   globally revoked per user (`/api/auth/logout-all`).
 - Cost: clients must implement refresh-on-401, and endpoints that can't send
-  headers (`<img>`, `EventSource`) need the `access_token=` query fallback.
+  headers (`EventSource`) authenticate via the refresh cookie instead. (An
+  earlier `access_token=` query fallback was removed: tokens in URLs leak into
+  proxy logs and browser history.)
 - Stateless access tokens can't be individually revoked before expiry — accepted,
   given the short TTL.

--- a/tests/auth/test_api_login_jwt.py
+++ b/tests/auth/test_api_login_jwt.py
@@ -130,3 +130,17 @@ async def test_login_rate_limiting(client: AsyncClient, test_user):
     
     # Should have at least one 429 (rate limit exceeded)
     assert 429 in status_codes, f"Expected rate limiting (429), got: {status_codes}"
+
+
+@pytest.mark.asyncio
+async def test_login_rejected_for_inactive_user(client: AsyncClient, test_user, db):
+    """Deactivated users must not be able to log in, even with valid credentials."""
+    await db.execute(
+        'UPDATE "user" SET is_active = FALSE WHERE id = $1', test_user["id"]
+    )
+
+    response = await client.post(
+        "/api/auth/login",
+        json={"username": "testuser_jwt", "password": "password123"},
+    )
+    assert response.status_code == 403

--- a/tests/auth/test_api_refresh_jwt.py
+++ b/tests/auth/test_api_refresh_jwt.py
@@ -151,6 +151,87 @@ async def test_refresh_token_reuse_detection(client: AsyncClient, test_user):
     # Try to reuse the old (now revoked) refresh token
     client.cookies.set("jamarr_refresh", first_refresh)
     refresh2 = await client.post("/api/auth/refresh")
-    
+
     # Should be rejected
     assert refresh2.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuse_within_grace_keeps_other_sessions(
+    client: AsyncClient, test_user, db
+):
+    """A replay right after rotation (benign race) must not nuke the new session."""
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"username": "testuser_jwt", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    first_refresh = login_response.cookies["jamarr_refresh"]
+
+    refresh1 = await client.post("/api/auth/refresh")
+    assert refresh1.status_code == 200
+
+    # Replay the just-rotated token immediately
+    client.cookies.set("jamarr_refresh", first_refresh)
+    refresh2 = await client.post("/api/auth/refresh")
+    assert refresh2.status_code == 401
+
+    # The rotated session must survive
+    active = await db.fetchval(
+        "SELECT COUNT(*) FROM auth_refresh_session WHERE user_id = $1 AND revoked_at IS NULL",
+        test_user["id"],
+    )
+    assert active == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuse_after_grace_revokes_all_sessions(
+    client: AsyncClient, test_user, db
+):
+    """A replay of an old rotated token is treated as theft: revoke everything."""
+    from app.auth_tokens import hash_refresh_token
+
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"username": "testuser_jwt", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    first_refresh = login_response.cookies["jamarr_refresh"]
+
+    refresh1 = await client.post("/api/auth/refresh")
+    assert refresh1.status_code == 200
+
+    # Pretend the rotation happened well outside the grace window
+    await db.execute(
+        "UPDATE auth_refresh_session SET revoked_at = NOW() - INTERVAL '10 minutes' "
+        "WHERE token_hash = $1",
+        hash_refresh_token(first_refresh),
+    )
+
+    client.cookies.set("jamarr_refresh", first_refresh)
+    refresh2 = await client.post("/api/auth/refresh")
+    assert refresh2.status_code == 401
+
+    # Every session for the user must now be revoked
+    active = await db.fetchval(
+        "SELECT COUNT(*) FROM auth_refresh_session WHERE user_id = $1 AND revoked_at IS NULL",
+        test_user["id"],
+    )
+    assert active == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejected_for_inactive_user(client: AsyncClient, test_user, db):
+    """Refresh must fail once the user is deactivated."""
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"username": "testuser_jwt", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+
+    await db.execute(
+        'UPDATE "user" SET is_active = FALSE WHERE id = $1', test_user["id"]
+    )
+
+    response = await client.post("/api/auth/refresh")
+    assert response.status_code == 401

--- a/tests/unit/test_upnp_discovery_backoff.py
+++ b/tests/unit/test_upnp_discovery_backoff.py
@@ -27,10 +27,10 @@ def _fail(discovery, n=1, bootid=None):
         discovery._track_failure(LOCATION, RuntimeError("boom"), bootid)
 
 
-def test_first_failure_logs_error(discovery, caplog):
+def test_first_failure_logs_warning(discovery, caplog):
     with caplog.at_level(logging.DEBUG, logger="app.services.upnp.discovery"):
         _fail(discovery)
-    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
     discovery.manager.log.assert_called_once()
 
 
@@ -67,9 +67,14 @@ def test_suspension_after_max_failures(discovery, caplog):
     assert state["cooldown_until"] == pytest.approx(
         time.time() + _SUSPENDED_RETRY_INTERVAL, abs=5
     )
-    # Exactly one WARNING at the moment of suspension, not on later failures.
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
+    # Exactly one suspension WARNING at the moment of suspension (the first
+    # failure logs its own WARNING), not on later failures.
+    suspensions = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "probing at most" in r.message
+    ]
+    assert len(suspensions) == 1
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="app.services.upnp.discovery"):
         _fail(discovery)
@@ -97,14 +102,14 @@ def test_bootid_preserved_when_failure_has_none(discovery):
     assert discovery._failure_state[LOCATION]["bootid"] == "1"
 
 
-def test_success_reset_makes_next_failure_error_again(discovery, caplog):
+def test_success_reset_makes_next_failure_warning_again(discovery, caplog):
     _fail(discovery, n=3)
     # _add_renderer pops state on success.
     discovery._failure_state.pop(LOCATION, None)
     caplog.clear()
     with caplog.at_level(logging.DEBUG, logger="app.services.upnp.discovery"):
         _fail(discovery)
-    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
 
 
 def test_unknown_location_always_attempted(discovery):

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -156,13 +156,6 @@ export interface User {
     last_login?: string | null;
 }
 
-export function withAccessToken(url: string): string {
-    const token = getAccessToken();
-    if (!token || url.includes("access_token=")) return url;
-    const sep = url.includes("?") ? "&" : "?";
-    return `${url}${sep}access_token=${encodeURIComponent(token)}`;
-}
-
 export function getArtUrl(sha1: string | null | undefined, size?: number): string {
     if (!sha1) return "";
     let url = `/api/art/file/${sha1}`;

--- a/web/src/routes/settings/library/+page.svelte
+++ b/web/src/routes/settings/library/+page.svelte
@@ -12,7 +12,7 @@
         triggerOptimize,
         syncLastfmScrobbles,
     } from "$lib/api";
-    import { getAccessToken, refreshAccessToken } from "$lib/stores/auth";
+    import { refreshAccessToken } from "$lib/stores/auth";
     import TabButton from "$lib/components/TabButton.svelte";
     import Checkbox from "$lib/components/Checkbox.svelte";
 
@@ -97,11 +97,10 @@
 
     onMount(async () => {
         await refreshAccessToken();
-        const token = getAccessToken();
-        const tokenParam = token ? `?access_token=${encodeURIComponent(token)}` : "";
 
-        // Connect to SSE
-        eventSource = new EventSource(`/api/library/events${tokenParam}`);
+        // Connect to SSE; authenticated by the httponly refresh cookie, since
+        // EventSource cannot send an Authorization header.
+        eventSource = new EventSource(`/api/library/events`);
 
         eventSource.onopen = () => {
             addLog("Connected to scan server.");
@@ -124,7 +123,7 @@
         };
 
         // Connect to Last.fm SSE
-        lastfmEventSource = new EventSource(`/api/lastfm/events${tokenParam}`);
+        lastfmEventSource = new EventSource(`/api/lastfm/events`);
 
         lastfmEventSource.onmessage = (event) => {
             try {


### PR DESCRIPTION
## Summary

Fixes the HIGH and MEDIUM findings from a codebase review (prod logs cross-referenced).

### Auth
- **Remove `?access_token=` query-param auth** — JWTs in URLs leak into reverse-proxy logs, browser history, and Referer. SSE endpoints (`/api/library/events`, `/api/lastfm/events`) now authenticate via the httponly refresh cookie (EventSource cannot send headers); everything else is Bearer-header only. Web client updated, docs/ADR updated.
- **Refresh-token reuse detection** — replaying a rotated refresh token >30s after rotation revokes all sessions for the user and logs `refresh_reuse_detected`; within 30s it's treated as a benign concurrent-refresh race (two tabs) and the surviving session is kept.
- **Inactive users rejected at login (403) and refresh (401)** — previously they could mint tokens that deps blocked downstream.

### Config hardening
- Production now fails fast at startup when `JWT_SECRET_KEY` is missing or still the `.env.example` placeholder, instead of 500ing on first login.
- `DB_PASS` lost its weak `jamarr` compose default — **prod/dev `.env` must set `DB_PASS` before deploying this** (`.env.example` already includes it).
- `REFRESH_COOKIE_SECURE=false` commented out in `.env.example` — copying it no longer overrides the production default of `true`.

### Reliability
- Stream and artwork handlers no longer pin a DB pool connection (max 20) for the entire file transfer; connections are acquired briefly and released before the response streams.
- Pillow resizing, mime sniffing, and monitoring log tailing moved off the event loop into the threadpool.
- First UPnP discovery failure logs WARNING instead of ERROR (failure state is in-memory; every restart re-logs one line per standby TV).

## Tests
- Backend: 390 passed, 1 skipped (5 new auth tests; 3 UPnP backoff tests updated for the level change)
- TUI: 11 passed
- Web: svelte-check, stylelint, vitest, vite build all pass

## Deploy note
Verify `DB_PASS` is present in the prod `.env` before deploying — compose now errors if unset.